### PR TITLE
Fix command mode for C_SE_NA_1 commands

### DIFF
--- a/src/remote/message/PointCommand.cpp
+++ b/src/remote/message/PointCommand.cpp
@@ -106,7 +106,7 @@ PointCommand::PointCommand(std::shared_ptr<Object::DataPoint> point,
     // float Setpoint Command (NORMALIZED)
   case C_SE_NA_1: {
     io = (InformationObject)SetpointCommandNormalized_create(
-        nullptr, informationObjectAddress, (float)value.load(), false,
+        nullptr, informationObjectAddress, (float)value.load(), select,
         static_cast<uint8_t>(quality.load()));
   } break;
 


### PR DESCRIPTION
Fix the command mode for C_SE_NA_1 points. This command was not executing a SELECT_AND_EXECUTE operation fixed in v1.17.0.