### PR TITLE
fix(server): use correct COT 20 for general station interrogation responses

### DIFF
--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -1324,7 +1324,7 @@ bool Server::interrogationHandler(void *parameter, IMasterConnection connection,
               auto g = batchMap.find(type);
               if (g == batchMap.end()) {
                 auto b = Remote::Message::Batch::create(
-                    CS101_COT_REQUESTED_BY_GENERAL_COUNTER);
+                    CS101_COT_INTERROGATED_BY_STATION);
                 b->addPoint(point);
                 batchMap[type] = std::move(b);
               } else {


### PR DESCRIPTION
## Description  
This PR fixes an incorrect use of **COT (Cause of Transmission)** values in the handling of general station interrogation (QOI=20).  

## Issue  
- The `interrogationHandler` erroneously used `CS101_COT_REQUESTED_BY_GENERAL_COUNTER` (COT=37) for non-counter data responses.  
- COT=37 is reserved for counter interrogation (C_CI_NA_1, Type ID=101), not general station interrogation (C_IC_NA_1, Type ID=100).  

## Changes  
- Replaced `CS101_COT_REQUESTED_BY_GENERAL_COUNTER` (37) with `CS101_COT_INTERROGATED_BY_STATION` (20) for all non-counter data points in the general station interrogation flow.