### PR TITLE
Move the default value to the header file

### DIFF
--- a/src/object/DateTime.cpp
+++ b/src/object/DateTime.cpp
@@ -32,8 +32,7 @@
 #include "DateTime.h"
 #include "types.h"
 
-DateTime::DateTime(const std::chrono::system_clock::time_point t =
-                       std::chrono::system_clock::now())
+DateTime::DateTime(const std::chrono::system_clock::time_point t)
     : time(t), substituted(false), invalid(false), summertime(false) {}
 
 DateTime::DateTime(CP56Time2a t) {

--- a/src/object/DateTime.h
+++ b/src/object/DateTime.h
@@ -37,7 +37,7 @@
 
 class DateTime {
 public:
-  explicit DateTime(std::chrono::system_clock::time_point t);
+  explicit DateTime(std::chrono::system_clock::time_point t = std::chrono::system_clock::now());
 
   explicit DateTime(CP56Time2a t);
 


### PR DESCRIPTION
I was trying to build the library on OS X and Apple's version of Clang was failing on this as the default values are supposed to be part of the declaration and not definition.