### PR TITLE
Fix DateTime constructor default argument handling for macOS

### DIFF
--- a/src/object/DateTime.cpp
+++ b/src/object/DateTime.cpp
@@ -32,10 +32,15 @@
 #include "DateTime.h"
 #include "types.h"
 
+#if defined(__APPLE__)
+DateTime::DateTime(const std::chrono::system_clock::time_point t)
+    : time(t), substituted(false), invalid(false), summertime(false) {}
+#else
+
 DateTime::DateTime(const std::chrono::system_clock::time_point t =
                        std::chrono::system_clock::now())
-    : time(t), substituted(false), invalid(false), summertime(false) {}
-
+                           : time(t), substituted(false), invalid(false), summertime(false) {}
+#endif
 DateTime::DateTime(CP56Time2a t) {
   time = to_time_point(t);
   invalid = CP56Time2a_isInvalid(t);

--- a/src/object/DateTime.h
+++ b/src/object/DateTime.h
@@ -37,8 +37,14 @@
 
 class DateTime {
 public:
+#if defined(__APPLE__)
+  // On Apple platforms, default to system_clock::now()
+  explicit DateTime(std::chrono::system_clock::time_point t =
+                        std::chrono::system_clock::now());
+#else
+  // On all other platforms, require explicit timestamp
   explicit DateTime(std::chrono::system_clock::time_point t);
-
+#endif
   explicit DateTime(CP56Time2a t);
 
   [[nodiscard]] std::chrono::system_clock::time_point getTime() const {


### PR DESCRIPTION
Although it is better to completely move the default arguments to header files as suggestted by [tomas789](https://github.com/Fraunhofer-FIT-DIEN/iec104-python/issues?q=is%3Apr+is%3Aopen+author%3Atomas789) due to the more aggressive nature of CMake on mac. this could be an alternative that allows mac users with intel cores to already start using this library.