### PR TITLE
Add file transfer Type IDs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,6 +175,8 @@ set(c104_SOURCES
     src/remote/TransportSecurity.h
     src/remote/Connection.cpp
     src/remote/Connection.h
+    src/remote/FileClient.cpp
+    src/remote/FileClient.h
     src/remote/message/IMessageInterface.h
     src/remote/message/IncomingMessage.cpp
     src/remote/message/IncomingMessage.h

--- a/src/python.cpp
+++ b/src/python.cpp
@@ -302,7 +302,136 @@ PY_MODULE(m) {
       .value("F_AF_NA_1", IEC60870_5_TypeID::F_AF_NA_1)
       .value("F_SG_NA_1", IEC60870_5_TypeID::F_SG_NA_1)
       .value("F_DR_TA_1", IEC60870_5_TypeID::F_DR_TA_1)
-      .value("F_SC_NB_1", IEC60870_5_TypeID::F_SC_NB_1);
+      .value("F_SC_NB_1", IEC60870_5_TypeID::F_SC_NB_1)
+      // Vendor-specific types (128-255)
+      .value("VENDOR_128", static_cast<IEC60870_5_TypeID>(128))
+      .value("VENDOR_129", static_cast<IEC60870_5_TypeID>(129))
+      .value("VENDOR_130", static_cast<IEC60870_5_TypeID>(130))
+      .value("VENDOR_131", static_cast<IEC60870_5_TypeID>(131))
+      .value("VENDOR_132", static_cast<IEC60870_5_TypeID>(132))
+      .value("VENDOR_133", static_cast<IEC60870_5_TypeID>(133))
+      .value("VENDOR_134", static_cast<IEC60870_5_TypeID>(134))
+      .value("VENDOR_135", static_cast<IEC60870_5_TypeID>(135))
+      .value("VENDOR_136", static_cast<IEC60870_5_TypeID>(136))
+      .value("VENDOR_137", static_cast<IEC60870_5_TypeID>(137))
+      .value("VENDOR_138", static_cast<IEC60870_5_TypeID>(138))
+      .value("VENDOR_139", static_cast<IEC60870_5_TypeID>(139))
+      .value("VENDOR_140", static_cast<IEC60870_5_TypeID>(140))
+      .value("VENDOR_141", static_cast<IEC60870_5_TypeID>(141))
+      .value("VENDOR_142", static_cast<IEC60870_5_TypeID>(142))
+      .value("VENDOR_143", static_cast<IEC60870_5_TypeID>(143))
+      .value("VENDOR_144", static_cast<IEC60870_5_TypeID>(144))
+      .value("VENDOR_145", static_cast<IEC60870_5_TypeID>(145))
+      .value("VENDOR_146", static_cast<IEC60870_5_TypeID>(146))
+      .value("VENDOR_147", static_cast<IEC60870_5_TypeID>(147))
+      .value("VENDOR_148", static_cast<IEC60870_5_TypeID>(148))
+      .value("VENDOR_149", static_cast<IEC60870_5_TypeID>(149))
+      .value("VENDOR_150", static_cast<IEC60870_5_TypeID>(150))
+      .value("VENDOR_151", static_cast<IEC60870_5_TypeID>(151))
+      .value("VENDOR_152", static_cast<IEC60870_5_TypeID>(152))
+      .value("VENDOR_153", static_cast<IEC60870_5_TypeID>(153))
+      .value("VENDOR_154", static_cast<IEC60870_5_TypeID>(154))
+      .value("VENDOR_155", static_cast<IEC60870_5_TypeID>(155))
+      .value("VENDOR_156", static_cast<IEC60870_5_TypeID>(156))
+      .value("VENDOR_157", static_cast<IEC60870_5_TypeID>(157))
+      .value("VENDOR_158", static_cast<IEC60870_5_TypeID>(158))
+      .value("VENDOR_159", static_cast<IEC60870_5_TypeID>(159))
+      .value("VENDOR_160", static_cast<IEC60870_5_TypeID>(160))
+      .value("VENDOR_161", static_cast<IEC60870_5_TypeID>(161))
+      .value("VENDOR_162", static_cast<IEC60870_5_TypeID>(162))
+      .value("VENDOR_163", static_cast<IEC60870_5_TypeID>(163))
+      .value("VENDOR_164", static_cast<IEC60870_5_TypeID>(164))
+      .value("VENDOR_165", static_cast<IEC60870_5_TypeID>(165))
+      .value("VENDOR_166", static_cast<IEC60870_5_TypeID>(166))
+      .value("VENDOR_167", static_cast<IEC60870_5_TypeID>(167))
+      .value("VENDOR_168", static_cast<IEC60870_5_TypeID>(168))
+      .value("VENDOR_169", static_cast<IEC60870_5_TypeID>(169))
+      .value("VENDOR_170", static_cast<IEC60870_5_TypeID>(170))
+      .value("VENDOR_171", static_cast<IEC60870_5_TypeID>(171))
+      .value("VENDOR_172", static_cast<IEC60870_5_TypeID>(172))
+      .value("VENDOR_173", static_cast<IEC60870_5_TypeID>(173))
+      .value("VENDOR_174", static_cast<IEC60870_5_TypeID>(174))
+      .value("VENDOR_175", static_cast<IEC60870_5_TypeID>(175))
+      .value("VENDOR_176", static_cast<IEC60870_5_TypeID>(176))
+      .value("VENDOR_177", static_cast<IEC60870_5_TypeID>(177))
+      .value("VENDOR_178", static_cast<IEC60870_5_TypeID>(178))
+      .value("VENDOR_179", static_cast<IEC60870_5_TypeID>(179))
+      .value("VENDOR_180", static_cast<IEC60870_5_TypeID>(180))
+      .value("VENDOR_181", static_cast<IEC60870_5_TypeID>(181))
+      .value("VENDOR_182", static_cast<IEC60870_5_TypeID>(182))
+      .value("VENDOR_183", static_cast<IEC60870_5_TypeID>(183))
+      .value("VENDOR_184", static_cast<IEC60870_5_TypeID>(184))
+      .value("VENDOR_185", static_cast<IEC60870_5_TypeID>(185))
+      .value("VENDOR_186", static_cast<IEC60870_5_TypeID>(186))
+      .value("VENDOR_187", static_cast<IEC60870_5_TypeID>(187))
+      .value("VENDOR_188", static_cast<IEC60870_5_TypeID>(188))
+      .value("VENDOR_189", static_cast<IEC60870_5_TypeID>(189))
+      .value("VENDOR_190", static_cast<IEC60870_5_TypeID>(190))
+      .value("VENDOR_191", static_cast<IEC60870_5_TypeID>(191))
+      .value("VENDOR_192", static_cast<IEC60870_5_TypeID>(192))
+      .value("VENDOR_193", static_cast<IEC60870_5_TypeID>(193))
+      .value("VENDOR_194", static_cast<IEC60870_5_TypeID>(194))
+      .value("VENDOR_195", static_cast<IEC60870_5_TypeID>(195))
+      .value("VENDOR_196", static_cast<IEC60870_5_TypeID>(196))
+      .value("VENDOR_197", static_cast<IEC60870_5_TypeID>(197))
+      .value("VENDOR_198", static_cast<IEC60870_5_TypeID>(198))
+      .value("VENDOR_199", static_cast<IEC60870_5_TypeID>(199))
+      .value("VENDOR_200", static_cast<IEC60870_5_TypeID>(200))
+      .value("VENDOR_201", static_cast<IEC60870_5_TypeID>(201))
+      .value("VENDOR_202", static_cast<IEC60870_5_TypeID>(202))
+      .value("VENDOR_203", static_cast<IEC60870_5_TypeID>(203))
+      .value("VENDOR_204", static_cast<IEC60870_5_TypeID>(204))
+      .value("VENDOR_205", static_cast<IEC60870_5_TypeID>(205))
+      .value("VENDOR_206", static_cast<IEC60870_5_TypeID>(206))
+      .value("VENDOR_207", static_cast<IEC60870_5_TypeID>(207))
+      .value("VENDOR_208", static_cast<IEC60870_5_TypeID>(208))
+      .value("VENDOR_209", static_cast<IEC60870_5_TypeID>(209))
+      .value("VENDOR_210", static_cast<IEC60870_5_TypeID>(210))
+      .value("VENDOR_211", static_cast<IEC60870_5_TypeID>(211))
+      .value("VENDOR_212", static_cast<IEC60870_5_TypeID>(212))
+      .value("VENDOR_213", static_cast<IEC60870_5_TypeID>(213))
+      .value("VENDOR_214", static_cast<IEC60870_5_TypeID>(214))
+      .value("VENDOR_215", static_cast<IEC60870_5_TypeID>(215))
+      .value("VENDOR_216", static_cast<IEC60870_5_TypeID>(216))
+      .value("VENDOR_217", static_cast<IEC60870_5_TypeID>(217))
+      .value("VENDOR_218", static_cast<IEC60870_5_TypeID>(218))
+      .value("VENDOR_219", static_cast<IEC60870_5_TypeID>(219))
+      .value("VENDOR_220", static_cast<IEC60870_5_TypeID>(220))
+      .value("VENDOR_221", static_cast<IEC60870_5_TypeID>(221))
+      .value("VENDOR_222", static_cast<IEC60870_5_TypeID>(222))
+      .value("VENDOR_223", static_cast<IEC60870_5_TypeID>(223))
+      .value("VENDOR_224", static_cast<IEC60870_5_TypeID>(224))
+      .value("VENDOR_225", static_cast<IEC60870_5_TypeID>(225))
+      .value("VENDOR_226", static_cast<IEC60870_5_TypeID>(226))
+      .value("VENDOR_227", static_cast<IEC60870_5_TypeID>(227))
+      .value("VENDOR_228", static_cast<IEC60870_5_TypeID>(228))
+      .value("VENDOR_229", static_cast<IEC60870_5_TypeID>(229))
+      .value("VENDOR_230", static_cast<IEC60870_5_TypeID>(230))
+      .value("VENDOR_231", static_cast<IEC60870_5_TypeID>(231))
+      .value("VENDOR_232", static_cast<IEC60870_5_TypeID>(232))
+      .value("VENDOR_233", static_cast<IEC60870_5_TypeID>(233))
+      .value("VENDOR_234", static_cast<IEC60870_5_TypeID>(234))
+      .value("VENDOR_235", static_cast<IEC60870_5_TypeID>(235))
+      .value("VENDOR_236", static_cast<IEC60870_5_TypeID>(236))
+      .value("VENDOR_237", static_cast<IEC60870_5_TypeID>(237))
+      .value("VENDOR_238", static_cast<IEC60870_5_TypeID>(238))
+      .value("VENDOR_239", static_cast<IEC60870_5_TypeID>(239))
+      .value("VENDOR_240", static_cast<IEC60870_5_TypeID>(240))
+      .value("VENDOR_241", static_cast<IEC60870_5_TypeID>(241))
+      .value("VENDOR_242", static_cast<IEC60870_5_TypeID>(242))
+      .value("VENDOR_243", static_cast<IEC60870_5_TypeID>(243))
+      .value("VENDOR_244", static_cast<IEC60870_5_TypeID>(244))
+      .value("VENDOR_245", static_cast<IEC60870_5_TypeID>(245))
+      .value("VENDOR_246", static_cast<IEC60870_5_TypeID>(246))
+      .value("VENDOR_247", static_cast<IEC60870_5_TypeID>(247))
+      .value("VENDOR_248", static_cast<IEC60870_5_TypeID>(248))
+      .value("VENDOR_249", static_cast<IEC60870_5_TypeID>(249))
+      .value("VENDOR_250", static_cast<IEC60870_5_TypeID>(250))
+      .value("VENDOR_251", static_cast<IEC60870_5_TypeID>(251))
+      .value("VENDOR_252", static_cast<IEC60870_5_TypeID>(252))
+      .value("VENDOR_253", static_cast<IEC60870_5_TypeID>(253))
+      .value("VENDOR_254", static_cast<IEC60870_5_TypeID>(254))
+      .value("VENDOR_255", static_cast<IEC60870_5_TypeID>(255));
 
   py::enum_<CS101_CauseOfTransmission>(
       m, "Cot",
@@ -2422,6 +2551,336 @@ Example
 )def",
           "common_address"_a, "ioa"_a, "wait_for_response"_a = true,
           py::return_value_policy::copy)
+      .def(
+          "file_call", &Remote::Connection::fileCall,
+          R"def(file_call(self: c104.Connection, common_address: int, ioa: int, nof: int) -> bool
+
+request file transfer from the remote terminal unit (server)
+sends F_SC_NA_1 (Type 122) with SCQ=2 (REQUEST_FILE)
+server responds with F_SR_NA_1 (Type 121 - SECTION_READY)
+
+Parameters
+----------
+common_address: int
+    station common address
+ioa: int
+    information object address of the file
+nof: int
+    name of file (file type identifier)
+
+Returns
+-------
+bool
+    True, if message was sent successfully
+
+Example
+-------
+>>> if my_connection.file_call(common_address=1, ioa=30000, nof=1):
+>>>     print("File call sent")
+)def",
+          "common_address"_a, "ioa"_a, "nof"_a, py::return_value_policy::copy)
+      .def(
+          "section_call", &Remote::Connection::sectionCall,
+          R"def(section_call(self: c104.Connection, common_address: int, ioa: int, nof: int, nos: int) -> bool
+
+request section transfer from the remote terminal unit (server)
+sends F_SC_NA_1 (Type 122) with SCQ=6 (REQUEST_SECTION)
+server responds with F_SG_NA_1 (Type 125 - FILE_SEGMENT) messages
+
+Parameters
+----------
+common_address: int
+    station common address
+ioa: int
+    information object address of the file
+nof: int
+    name of file (file type identifier)
+nos: int
+    name of section (section number, 0-255)
+
+Returns
+-------
+bool
+    True, if message was sent successfully
+
+Example
+-------
+>>> if my_connection.section_call(common_address=1, ioa=30000, nof=1, nos=0):
+>>>     print("Section call sent")
+)def",
+          "common_address"_a, "ioa"_a, "nof"_a, "nos"_a,
+          py::return_value_policy::copy)
+      .def(
+          "file_ack", &Remote::Connection::fileAck,
+          R"def(file_ack(self: c104.Connection, common_address: int, ioa: int, nof: int, nos: int, afq: int) -> bool
+
+send file/section acknowledgment to the remote terminal unit (server)
+sends F_AF_NA_1 (Type 124)
+
+Parameters
+----------
+common_address: int
+    station common address
+ioa: int
+    information object address of the file
+nof: int
+    name of file (file type identifier)
+nos: int
+    name of section (0 for file acknowledgment)
+afq: int
+    acknowledge file qualifier (1=pos_file, 2=neg_file, 3=pos_section, 4=neg_section)
+
+Returns
+-------
+bool
+    True, if message was sent successfully
+
+Example
+-------
+>>> if my_connection.file_ack(common_address=1, ioa=30000, nof=1, nos=0, afq=1):
+>>>     print("File acknowledged")
+)def",
+          "common_address"_a, "ioa"_a, "nof"_a, "nos"_a, "afq"_a,
+          py::return_value_policy::copy)
+      .def(
+          "delete_file", &Remote::Connection::deleteFile,
+          R"def(delete_file(self: c104.Connection, common_address: int, ioa: int) -> bool
+
+send a file delete command to the remote terminal unit (server)
+
+WARNING: This is a DESTRUCTIVE operation! The file will be permanently deleted
+on the remote device. Use with extreme caution.
+
+This sends F_SC_NA_1 (Type 122) with SCQ=4 (DELETE_FILE) and COT=FILE_TRANSFER.
+The server should respond with F_AF_NA_1 (Type 124) acknowledgment.
+
+Parameters
+----------
+common_address: int
+    station common address (1-65534)
+ioa: int
+    information object address of the file to delete
+
+Returns
+-------
+bool
+    True if the delete command was sent successfully (NOT confirmation of deletion)
+
+Example
+-------
+>>> # WARNING: This will delete the file!
+>>> if my_connection.delete_file(common_address=1, ioa=10001):
+>>>     print("Delete command sent")
+>>> else:
+>>>     print("Failed to send delete command")
+)def",
+          "common_address"_a, "ioa"_a,
+          py::return_value_policy::copy)
+      .def(
+          "download_file", &Remote::Connection::downloadFile,
+          R"def(download_file(self: c104.Connection, common_address: int, ioa: int, timeout_ms: int = 30000) -> bytes
+
+download a file from the remote terminal unit (server)
+this is a blocking high-level API that handles the complete file transfer protocol:
+1. SELECT file (F_SC_NA_1 SCQ=1) -> wait for FILE_READY (F_FR_NA_1)
+2. CALL file (F_SC_NA_1 SCQ=2) -> wait for SECTION_READY (F_SR_NA_1)
+3. For each section:
+   - CALL section (F_SC_NA_1 SCQ=6)
+   - Receive segments (F_SG_NA_1)
+   - Receive last segment (F_LS_NA_1) with checksum
+   - Send section ACK (F_AF_NA_1)
+4. Send file ACK (F_AF_NA_1)
+
+Parameters
+----------
+common_address: int
+    station common address
+ioa: int
+    information object address of the file
+timeout_ms: int
+    maximum time to wait for complete transfer in milliseconds (default: 30000)
+
+Returns
+-------
+bytes
+    file data as bytes, empty bytes on failure
+
+Example
+-------
+>>> data = my_connection.download_file(common_address=1, ioa=30000, timeout_ms=30000)
+>>> if data:
+>>>     print(f"Downloaded {len(data)} bytes")
+>>>     with open("downloaded_file.bin", "wb") as f:
+>>>         f.write(data)
+>>> else:
+>>>     print("Download failed")
+)def",
+          "common_address"_a, "ioa"_a, "timeout_ms"_a = 30000,
+          py::return_value_policy::copy)
+      .def(
+          "browse_directory",
+          [](Remote::Connection &self, std::uint_fast16_t commonAddress,
+             std::uint_fast32_t ioa, std::uint_fast32_t timeout_ms) {
+            auto entries = self.browseDirectory(commonAddress, ioa, timeout_ms);
+            py::list result;
+            for (const auto &entry : entries) {
+              py::dict d;
+              d["ioa"] = entry.ioa;
+              d["nof"] = entry.nof;
+              d["length"] = entry.lengthOfFile;
+              d["sof"] = entry.sof;
+              d["last_file"] = entry.lastFile;
+              d["is_directory"] = entry.isDirectory;
+              d["file_active"] = entry.fileActive;
+              d["creation_time"] = entry.creationTime;
+              result.append(d);
+            }
+            return result;
+          },
+          R"def(browse_directory(self: c104.Connection, common_address: int, ioa: int = 0, timeout_ms: int = 30000) -> list[dict]
+
+browse the remote terminal unit's file directory
+
+this is a blocking high-level API that sends F_SC_NA_1 with COT=REQUEST
+and waits for F_DR_TA_1 directory entries until the last entry (LFD=1) is received.
+
+Parameters
+----------
+common_address: int
+    station common address (1-65534)
+ioa: int
+    information object address (typically 0 for root directory, default: 0)
+timeout_ms: int
+    maximum time to wait for complete directory in milliseconds (default: 30000)
+
+Returns
+-------
+list[dict]
+    list of directory entries, each dict contains:
+    - ioa (int): Information Object Address (file identifier)
+    - nof (int): Name Of File (file type: 1=transparent, 2=disturbance)
+    - length (int): File size in bytes
+    - sof (int): Status Of File byte (raw)
+    - last_file (bool): LFD flag - last file of directory
+    - is_directory (bool): FOR flag - True if directory, False if file
+    - file_active (bool): FA flag - True if file is being transferred
+    - creation_time (int): File creation timestamp in milliseconds since epoch
+    empty list on failure
+
+Example
+-------
+>>> entries = my_connection.browse_directory(common_address=1, ioa=0, timeout_ms=30000)
+>>> for entry in entries:
+>>>     print(f"IOA: {entry['ioa']}, Size: {entry['length']}, Type: {entry['nof']}")
+>>> if not entries:
+>>>     print("Directory browsing failed or no files found")
+)def",
+          "common_address"_a, "ioa"_a = 0, "timeout_ms"_a = 30000,
+          py::return_value_policy::copy)
+      .def(
+          "query_log", &Remote::Connection::queryLog,
+          R"def(query_log(self: c104.Connection, common_address: int, ioa: int, nof: int, start_time_ms: int, stop_time_ms: int) -> bool
+
+query archived log data with time range (F_SC_NB_1, Type 127)
+
+this sends F_SC_NB_1 (call/select with time tag) to request archived log data
+within a specified time range. the server should respond with F_FR_NA_1 (file ready)
+if matching data is available, which can then be downloaded using download_file().
+
+Parameters
+----------
+common_address: int
+    station common address (1-65534)
+ioa: int
+    information object address (log file identifier)
+nof: int
+    name of file (file type: 1=transparent, 2=disturbance, 3=events, 4=analogue, etc.)
+start_time_ms: int
+    start of time range in milliseconds since epoch (UTC)
+stop_time_ms: int
+    end of time range in milliseconds since epoch (UTC)
+
+Returns
+-------
+bool
+    True if query was sent successfully, False on error
+
+Example
+-------
+>>> from datetime import datetime, timezone
+>>> # Query disturbance records from last hour
+>>> end_time = int(datetime.now(timezone.utc).timestamp() * 1000)
+>>> start_time = end_time - 3600000  # 1 hour ago
+>>> success = my_connection.query_log(
+...     common_address=1,
+...     ioa=30000,
+...     nof=2,  # disturbance data
+...     start_time_ms=start_time,
+...     stop_time_ms=end_time
+... )
+>>> if success:
+...     print("Query sent - wait for file ready callback")
+)def",
+          "common_address"_a, "ioa"_a, "nof"_a, "start_time_ms"_a, "stop_time_ms"_a)
+      .def(
+          "upload_file",
+          [](Remote::Connection &self, std::uint_fast16_t commonAddress,
+             std::uint_fast32_t ioa, std::uint_fast16_t nof,
+             py::bytes data, std::uint_fast32_t timeout_ms) {
+            // Convert py::bytes to std::vector<uint8_t>
+            std::string s = data;
+            std::vector<uint8_t> vec(s.begin(), s.end());
+            return self.uploadFile(commonAddress, ioa, nof, vec, timeout_ms);
+          },
+          R"def(upload_file(self: c104.Connection, common_address: int, ioa: int, nof: int, data: bytes, timeout_ms: int = 30000) -> bool
+
+upload a file to the remote terminal unit (server)
+
+WARNING: This is a WRITE operation that modifies the remote device!
+Only use this in authorized testing environments.
+
+This is a blocking high-level API that handles the complete file upload protocol:
+1. Send FILE_READY (F_FR_NA_1) with file length
+2. Send SECTION_READY (F_SR_NA_1) with section length
+3. Send file segments (F_SG_NA_1) in chunks of max 240 bytes
+4. Send LAST_SEGMENT (F_LS_NA_1) with checksum
+5. Wait for file ACK (F_AF_NA_1) from server
+
+Parameters
+----------
+common_address: int
+    station common address (1-65534)
+ioa: int
+    information object address for the file (file identifier)
+nof: int
+    name of file type (1=transparent file, 2=disturbance recording)
+data: bytes
+    file content to upload
+timeout_ms: int
+    maximum time to wait for acknowledgment in milliseconds (default: 30000)
+
+Returns
+-------
+bool
+    True if upload completed successfully, False on error or timeout
+
+Example
+-------
+>>> with open("config.bin", "rb") as f:
+...     data = f.read()
+>>> success = my_connection.upload_file(
+...     common_address=1,
+...     ioa=30000,
+...     nof=1,  # transparent file
+...     data=data,
+...     timeout_ms=60000
+... )
+>>> if success:
+...     print(f"Uploaded {len(data)} bytes successfully")
+>>> else:
+...     print("Upload failed")
+)def",
+          "common_address"_a, "ioa"_a, "nof"_a, "data"_a, "timeout_ms"_a = 30000)
       .def(
           "add_station", &Remote::Connection::addStation,
           R"def(add_station(self: c104.Connection, common_address: int) -> c104.Station | None

--- a/src/remote/Connection.cpp
+++ b/src/remote/Connection.cpp
@@ -31,6 +31,7 @@
 
 #include "Connection.h"
 #include "Client.h"
+#include "FileClient.h"
 #include "module/ScopedGilAcquire.h"
 #include "module/ScopedGilRelease.h"
 #include "remote/Helper.h"
@@ -977,6 +978,458 @@ bool Connection::fileSelect(std::uint_fast16_t commonAddress,
   return result;
 }
 
+bool Connection::fileCall(std::uint_fast16_t commonAddress,
+                          std::uint_fast32_t ioa,
+                          std::uint_fast16_t nof) {
+  Module::ScopedGilRelease const scoped("Connection.fileCall");
+
+  if (!isOpen())
+    return false;
+
+  std::unique_lock<Module::GilAwareMutex> lock(connection_mutex);
+  CS101_AppLayerParameters alParams =
+      CS104_Connection_getAppLayerParameters(connection);
+
+  CS101_ASDU asdu =
+      CS101_ASDU_create(alParams, false, CS101_COT_FILE_TRANSFER, 0,
+                        static_cast<int>(commonAddress), false, false);
+
+  // SCQ = 2 means "request file" (call file)
+  FileCallOrSelect io =
+      FileCallOrSelect_create(NULL, static_cast<int>(ioa), nof, 0, 2);
+
+  CS101_ASDU_addInformationObject(asdu, (InformationObject)io);
+  InformationObject_destroy((InformationObject)io);
+
+  bool const result = CS104_Connection_sendASDU(connection, asdu);
+  lock.unlock();
+
+  CS101_ASDU_destroy(asdu);
+
+  DEBUG_PRINT(Debug::Connection, "fileCall] CA=" + std::to_string(commonAddress) +
+              " IOA=" + std::to_string(ioa) + " NOF=" + std::to_string(nof) +
+              " Result=" + std::to_string(result));
+  return result;
+}
+
+bool Connection::sectionCall(std::uint_fast16_t commonAddress,
+                             std::uint_fast32_t ioa,
+                             std::uint_fast16_t nof,
+                             std::uint_fast8_t nos) {
+  Module::ScopedGilRelease const scoped("Connection.sectionCall");
+
+  if (!isOpen())
+    return false;
+
+  std::unique_lock<Module::GilAwareMutex> lock(connection_mutex);
+  CS101_AppLayerParameters alParams =
+      CS104_Connection_getAppLayerParameters(connection);
+
+  CS101_ASDU asdu =
+      CS101_ASDU_create(alParams, false, CS101_COT_FILE_TRANSFER, 0,
+                        static_cast<int>(commonAddress), false, false);
+
+  // SCQ = 6 means "request section" (call section)
+  FileCallOrSelect io =
+      FileCallOrSelect_create(NULL, static_cast<int>(ioa), nof, nos, 6);
+
+  CS101_ASDU_addInformationObject(asdu, (InformationObject)io);
+  InformationObject_destroy((InformationObject)io);
+
+  bool const result = CS104_Connection_sendASDU(connection, asdu);
+  lock.unlock();
+
+  CS101_ASDU_destroy(asdu);
+
+  DEBUG_PRINT(Debug::Connection, "sectionCall] CA=" + std::to_string(commonAddress) +
+              " IOA=" + std::to_string(ioa) + " NOF=" + std::to_string(nof) +
+              " NOS=" + std::to_string(nos) + " Result=" + std::to_string(result));
+  return result;
+}
+
+bool Connection::fileAck(std::uint_fast16_t commonAddress,
+                         std::uint_fast32_t ioa,
+                         std::uint_fast16_t nof,
+                         std::uint_fast8_t nos,
+                         std::uint_fast8_t afq) {
+  Module::ScopedGilRelease const scoped("Connection.fileAck");
+
+  if (!isOpen())
+    return false;
+
+  std::unique_lock<Module::GilAwareMutex> lock(connection_mutex);
+  CS101_AppLayerParameters alParams =
+      CS104_Connection_getAppLayerParameters(connection);
+
+  CS101_ASDU asdu =
+      CS101_ASDU_create(alParams, false, CS101_COT_FILE_TRANSFER, 0,
+                        static_cast<int>(commonAddress), false, false);
+
+  // Create FileACK information object
+  FileACK io = FileACK_create(NULL, static_cast<int>(ioa), nof, nos, afq);
+
+  CS101_ASDU_addInformationObject(asdu, (InformationObject)io);
+  InformationObject_destroy((InformationObject)io);
+
+  bool const result = CS104_Connection_sendASDU(connection, asdu);
+  lock.unlock();
+
+  CS101_ASDU_destroy(asdu);
+
+  DEBUG_PRINT(Debug::Connection, "fileAck] CA=" + std::to_string(commonAddress) +
+              " IOA=" + std::to_string(ioa) + " NOF=" + std::to_string(nof) +
+              " NOS=" + std::to_string(nos) + " AFQ=" + std::to_string(afq) +
+              " Result=" + std::to_string(result));
+  return result;
+}
+
+bool Connection::deleteFile(std::uint_fast16_t commonAddress,
+                            std::uint_fast32_t ioa) {
+  Module::ScopedGilRelease const scoped("Connection.deleteFile");
+
+  if (!isOpen())
+    return false;
+
+  // Create ASDU for file delete (F_SC_NA_1, Type 122)
+  std::unique_lock<Module::GilAwareMutex> lock(connection_mutex);
+  CS101_AppLayerParameters alParams =
+      CS104_Connection_getAppLayerParameters(connection);
+
+  CS101_ASDU asdu =
+      CS101_ASDU_create(alParams, false, CS101_COT_FILE_TRANSFER, 0,
+                        static_cast<int>(commonAddress), false, false);
+
+  // Create FileCallOrSelect information object
+  // SCQ = 4 means "delete file" (IEC60870_SCQ_DELETE_FILE)
+  FileCallOrSelect io =
+      FileCallOrSelect_create(NULL, static_cast<int>(ioa), CS101_NOF_TRANSPARENT_FILE, 0, 4);
+
+  CS101_ASDU_addInformationObject(asdu, (InformationObject)io);
+  InformationObject_destroy((InformationObject)io);
+
+  bool const result = CS104_Connection_sendASDU(connection, asdu);
+  lock.unlock();
+
+  CS101_ASDU_destroy(asdu);
+
+  DEBUG_PRINT(Debug::Connection, "deleteFile] CA=" + std::to_string(commonAddress) +
+              " IOA=" + std::to_string(ioa) + " Result=" + std::to_string(result));
+  return result;
+}
+
+std::vector<std::uint8_t> Connection::downloadFile(std::uint_fast16_t commonAddress,
+                                                   std::uint_fast32_t ioa,
+                                                   std::uint_fast32_t timeout_ms) {
+  Module::ScopedGilRelease const scoped("Connection.downloadFile");
+
+  if (!isOpen())
+    return {};
+
+  // Create FileClient if needed
+  if (!fileClient) {
+    fileClient = FileClient::create(weak_from_this());
+  }
+
+  return fileClient->downloadFile(static_cast<uint16_t>(commonAddress),
+                                  static_cast<uint32_t>(ioa),
+                                  static_cast<uint32_t>(timeout_ms));
+}
+
+std::shared_ptr<FileClient> Connection::getFileClient() {
+  if (!fileClient) {
+    fileClient = FileClient::create(weak_from_this());
+  }
+  return fileClient;
+}
+
+bool Connection::directoryRequest(std::uint_fast16_t commonAddress,
+                                  std::uint_fast32_t ioa) {
+  Module::ScopedGilRelease const scoped("Connection.directoryRequest");
+
+  if (!isOpen())
+    return false;
+
+  // Create ASDU for directory request (F_SC_NA_1, Type 122 with COT=REQUEST)
+  std::unique_lock<Module::GilAwareMutex> lock(connection_mutex);
+  CS101_AppLayerParameters alParams =
+      CS104_Connection_getAppLayerParameters(connection);
+
+  // COT=REQUEST (5) triggers directory listing
+  CS101_ASDU asdu =
+      CS101_ASDU_create(alParams, false, CS101_COT_REQUEST, 0,
+                        static_cast<int>(commonAddress), false, false);
+
+  // Create FileCallOrSelect information object
+  // SCQ = 1 (select) with COT=REQUEST signals directory request
+  FileCallOrSelect io =
+      FileCallOrSelect_create(NULL, static_cast<int>(ioa), CS101_NOF_DEFAULT, 0, 1);
+
+  CS101_ASDU_addInformationObject(asdu, (InformationObject)io);
+  InformationObject_destroy((InformationObject)io);
+
+  bool const result = CS104_Connection_sendASDU(connection, asdu);
+  lock.unlock();
+
+  CS101_ASDU_destroy(asdu);
+
+  DEBUG_PRINT(Debug::Connection, "directoryRequest] CA=" +
+              std::to_string(commonAddress) + " IOA=" + std::to_string(ioa) +
+              " Result=" + std::to_string(result));
+  return result;
+}
+
+bool Connection::queryLog(std::uint_fast16_t commonAddress,
+                          std::uint_fast32_t ioa,
+                          std::uint_fast16_t nof,
+                          std::uint_fast64_t startTime_ms,
+                          std::uint_fast64_t stopTime_ms) {
+  Module::ScopedGilRelease const scoped("Connection.queryLog");
+
+  if (!isOpen())
+    return false;
+
+  // Create ASDU for query log (F_SC_NB_1, Type 127)
+  std::unique_lock<Module::GilAwareMutex> lock(connection_mutex);
+  CS101_AppLayerParameters alParams =
+      CS104_Connection_getAppLayerParameters(connection);
+
+  // COT=FILE_TRANSFER for log query
+  CS101_ASDU asdu =
+      CS101_ASDU_create(alParams, false, CS101_COT_FILE_TRANSFER, 0,
+                        static_cast<int>(commonAddress), false, false);
+
+  // Convert timestamps to CP56Time2a format
+  struct sCP56Time2a startTime;
+  struct sCP56Time2a stopTime;
+  CP56Time2a_setFromMsTimestamp(&startTime, startTime_ms);
+  CP56Time2a_setFromMsTimestamp(&stopTime, stopTime_ms);
+
+  // Create QueryLog information object (F_SC_NB_1 = Type 127)
+  QueryLog io = QueryLog_create(NULL, static_cast<int>(ioa),
+                                static_cast<uint16_t>(nof),
+                                &startTime, &stopTime);
+
+  CS101_ASDU_addInformationObject(asdu, (InformationObject)io);
+  InformationObject_destroy((InformationObject)io);
+
+  bool const result = CS104_Connection_sendASDU(connection, asdu);
+  lock.unlock();
+
+  CS101_ASDU_destroy(asdu);
+
+  DEBUG_PRINT(Debug::Connection, "queryLog] CA=" +
+              std::to_string(commonAddress) + " IOA=" + std::to_string(ioa) +
+              " NOF=" + std::to_string(nof) +
+              " StartTime=" + std::to_string(startTime_ms) +
+              " StopTime=" + std::to_string(stopTime_ms) +
+              " Result=" + std::to_string(result));
+  return result;
+}
+
+std::vector<DirectoryEntry> Connection::browseDirectory(std::uint_fast16_t commonAddress,
+                                                        std::uint_fast32_t ioa,
+                                                        std::uint_fast32_t timeout_ms) {
+  Module::ScopedGilRelease const scoped("Connection.browseDirectory");
+
+  if (!isOpen())
+    return {};
+
+  // Create FileClient if needed
+  if (!fileClient) {
+    fileClient = FileClient::create(weak_from_this());
+  }
+
+  return fileClient->browseDirectory(static_cast<uint16_t>(commonAddress),
+                                     static_cast<uint32_t>(ioa),
+                                     static_cast<uint32_t>(timeout_ms));
+}
+
+bool Connection::uploadFile(std::uint_fast16_t commonAddress,
+                            std::uint_fast32_t ioa,
+                            std::uint_fast16_t nof,
+                            const std::vector<std::uint8_t>& data,
+                            std::uint_fast32_t timeout_ms) {
+  Module::ScopedGilRelease const scoped("Connection.uploadFile");
+
+  if (!isOpen())
+    return false;
+
+  // Create FileClient if needed
+  if (!fileClient) {
+    fileClient = FileClient::create(weak_from_this());
+  }
+
+  return fileClient->uploadFile(static_cast<uint16_t>(commonAddress),
+                                static_cast<uint32_t>(ioa),
+                                static_cast<uint16_t>(nof),
+                                data,
+                                static_cast<uint32_t>(timeout_ms));
+}
+
+bool Connection::sendFileReady(std::uint_fast16_t commonAddress,
+                               std::uint_fast32_t ioa,
+                               std::uint_fast16_t nof,
+                               std::uint_fast32_t length) {
+  Module::ScopedGilRelease const scoped("Connection.sendFileReady");
+
+  if (!isOpen())
+    return false;
+
+  std::unique_lock<Module::GilAwareMutex> lock(connection_mutex);
+  CS101_AppLayerParameters alParams =
+      CS104_Connection_getAppLayerParameters(connection);
+
+  // Create ASDU for File Ready (F_FR_NA_1, Type 120)
+  CS101_ASDU asdu =
+      CS101_ASDU_create(alParams, false, CS101_COT_FILE_TRANSFER, 0,
+                        static_cast<int>(commonAddress), false, false);
+
+  // Create FileReady information object
+  // FRQ = 0 for positive file ready
+  FileReady io = FileReady_create(NULL, static_cast<int>(ioa),
+                                  static_cast<uint16_t>(nof),
+                                  static_cast<uint32_t>(length), 0);
+
+  CS101_ASDU_addInformationObject(asdu, (InformationObject)io);
+  InformationObject_destroy((InformationObject)io);
+
+  bool const result = CS104_Connection_sendASDU(connection, asdu);
+  lock.unlock();
+
+  CS101_ASDU_destroy(asdu);
+
+  DEBUG_PRINT(Debug::Connection, "sendFileReady] CA=" + std::to_string(commonAddress) +
+              " IOA=" + std::to_string(ioa) + " NOF=" + std::to_string(nof) +
+              " Length=" + std::to_string(length) + " Result=" + std::to_string(result));
+  return result;
+}
+
+bool Connection::sendSectionReady(std::uint_fast16_t commonAddress,
+                                  std::uint_fast32_t ioa,
+                                  std::uint_fast16_t nof,
+                                  std::uint_fast8_t nos,
+                                  std::uint_fast32_t length) {
+  Module::ScopedGilRelease const scoped("Connection.sendSectionReady");
+
+  if (!isOpen())
+    return false;
+
+  std::unique_lock<Module::GilAwareMutex> lock(connection_mutex);
+  CS101_AppLayerParameters alParams =
+      CS104_Connection_getAppLayerParameters(connection);
+
+  // Create ASDU for Section Ready (F_SR_NA_1, Type 121)
+  CS101_ASDU asdu =
+      CS101_ASDU_create(alParams, false, CS101_COT_FILE_TRANSFER, 0,
+                        static_cast<int>(commonAddress), false, false);
+
+  // Create SectionReady information object
+  // SRQ = 0 for section ready
+  SectionReady io = SectionReady_create(NULL, static_cast<int>(ioa),
+                                        static_cast<uint16_t>(nof),
+                                        static_cast<uint8_t>(nos),
+                                        static_cast<uint32_t>(length), 0);
+
+  CS101_ASDU_addInformationObject(asdu, (InformationObject)io);
+  InformationObject_destroy((InformationObject)io);
+
+  bool const result = CS104_Connection_sendASDU(connection, asdu);
+  lock.unlock();
+
+  CS101_ASDU_destroy(asdu);
+
+  DEBUG_PRINT(Debug::Connection, "sendSectionReady] CA=" + std::to_string(commonAddress) +
+              " IOA=" + std::to_string(ioa) + " NOF=" + std::to_string(nof) +
+              " NOS=" + std::to_string(nos) + " Length=" + std::to_string(length) +
+              " Result=" + std::to_string(result));
+  return result;
+}
+
+bool Connection::sendSegment(std::uint_fast16_t commonAddress,
+                             std::uint_fast32_t ioa,
+                             std::uint_fast16_t nof,
+                             std::uint_fast8_t nos,
+                             const std::uint8_t* data,
+                             std::size_t length) {
+  Module::ScopedGilRelease const scoped("Connection.sendSegment");
+
+  if (!isOpen())
+    return false;
+
+  std::unique_lock<Module::GilAwareMutex> lock(connection_mutex);
+  CS101_AppLayerParameters alParams =
+      CS104_Connection_getAppLayerParameters(connection);
+
+  // Create ASDU for File Segment (F_SG_NA_1, Type 125)
+  CS101_ASDU asdu =
+      CS101_ASDU_create(alParams, false, CS101_COT_FILE_TRANSFER, 0,
+                        static_cast<int>(commonAddress), false, false);
+
+  // Create FileSegment information object
+  FileSegment io = FileSegment_create(NULL, static_cast<int>(ioa),
+                                      static_cast<uint16_t>(nof),
+                                      static_cast<uint8_t>(nos),
+                                      const_cast<uint8_t*>(data),
+                                      static_cast<uint8_t>(length));
+
+  CS101_ASDU_addInformationObject(asdu, (InformationObject)io);
+  InformationObject_destroy((InformationObject)io);
+
+  bool const result = CS104_Connection_sendASDU(connection, asdu);
+  lock.unlock();
+
+  CS101_ASDU_destroy(asdu);
+
+  DEBUG_PRINT(Debug::Connection, "sendSegment] CA=" + std::to_string(commonAddress) +
+              " IOA=" + std::to_string(ioa) + " NOF=" + std::to_string(nof) +
+              " NOS=" + std::to_string(nos) + " Length=" + std::to_string(length) +
+              " Result=" + std::to_string(result));
+  return result;
+}
+
+bool Connection::sendLastSegment(std::uint_fast16_t commonAddress,
+                                 std::uint_fast32_t ioa,
+                                 std::uint_fast16_t nof,
+                                 std::uint_fast8_t nos,
+                                 std::uint_fast8_t lsq,
+                                 std::uint_fast8_t checksum) {
+  Module::ScopedGilRelease const scoped("Connection.sendLastSegment");
+
+  if (!isOpen())
+    return false;
+
+  std::unique_lock<Module::GilAwareMutex> lock(connection_mutex);
+  CS101_AppLayerParameters alParams =
+      CS104_Connection_getAppLayerParameters(connection);
+
+  // Create ASDU for Last Segment/Section (F_LS_NA_1, Type 123)
+  CS101_ASDU asdu =
+      CS101_ASDU_create(alParams, false, CS101_COT_FILE_TRANSFER, 0,
+                        static_cast<int>(commonAddress), false, false);
+
+  // Create FileLastSegmentOrSection information object
+  FileLastSegmentOrSection io = FileLastSegmentOrSection_create(
+      NULL, static_cast<int>(ioa),
+      static_cast<uint16_t>(nof),
+      static_cast<uint8_t>(nos),
+      static_cast<uint8_t>(lsq),
+      static_cast<uint8_t>(checksum));
+
+  CS101_ASDU_addInformationObject(asdu, (InformationObject)io);
+  InformationObject_destroy((InformationObject)io);
+
+  bool const result = CS104_Connection_sendASDU(connection, asdu);
+  lock.unlock();
+
+  CS101_ASDU_destroy(asdu);
+
+  DEBUG_PRINT(Debug::Connection, "sendLastSegment] CA=" + std::to_string(commonAddress) +
+              " IOA=" + std::to_string(ioa) + " NOF=" + std::to_string(nof) +
+              " NOS=" + std::to_string(nos) + " LSQ=" + std::to_string(lsq) +
+              " CHS=" + std::to_string(checksum) + " Result=" + std::to_string(result));
+  return result;
+}
+
 bool Connection::transmit(std::shared_ptr<Object::DataPoint> point,
                           const CS101_CauseOfTransmission cause) {
   auto type = point->getType();
@@ -1182,6 +1635,105 @@ bool Connection::asduHandler(void *parameter, int address, CS101_ASDU asdu) {
     const auto parameters =
         CS104_Connection_getAppLayerParameters(instance->connection);
 
+    // Check for file transfer types BEFORE creating IncomingMessage
+    // (IncomingMessage throws exception for file transfer types)
+    IEC60870_5_TypeID rawType = CS101_ASDU_getTypeID(asdu);
+
+    if (rawType >= F_FR_NA_1 && rawType <= F_DR_TA_1) {
+      auto fc = instance->getFileClient();
+      if (fc) {
+        switch (rawType) {
+        case F_FR_NA_1: { // File Ready (120)
+          const auto io = reinterpret_cast<FileReady>(
+              CS101_ASDU_getElement(asdu, 0));
+          if (io) {
+            fc->handleFileReady(
+                FileReady_getNOF(io),
+                FileReady_getLengthOfFile(io),
+                FileReady_getFRQ(io),
+                FileReady_isPositive(io));
+            handled = true;
+          }
+          break;
+        }
+        case F_SR_NA_1: { // Section Ready (121)
+          const auto io = reinterpret_cast<SectionReady>(
+              CS101_ASDU_getElement(asdu, 0));
+          if (io) {
+            fc->handleSectionReady(
+                SectionReady_getNOF(io),
+                SectionReady_getNameOfSection(io),
+                SectionReady_getLengthOfSection(io),
+                SectionReady_getSRQ(io),
+                SectionReady_isNotReady(io));
+            handled = true;
+          }
+          break;
+        }
+        case F_SG_NA_1: { // File Segment (125)
+          const auto io = reinterpret_cast<FileSegment>(
+              CS101_ASDU_getElement(asdu, 0));
+          if (io) {
+            fc->handleSegment(
+                FileSegment_getNOF(io),
+                FileSegment_getNameOfSection(io),
+                FileSegment_getSegmentData(io),
+                FileSegment_getLengthOfSegment(io));
+            handled = true;
+          }
+          break;
+        }
+        case F_LS_NA_1: { // Last Segment/Section (123)
+          const auto io = reinterpret_cast<FileLastSegmentOrSection>(
+              CS101_ASDU_getElement(asdu, 0));
+          if (io) {
+            fc->handleLastSegmentOrSection(
+                FileLastSegmentOrSection_getNOF(io),
+                FileLastSegmentOrSection_getNameOfSection(io),
+                FileLastSegmentOrSection_getLSQ(io),
+                FileLastSegmentOrSection_getCHS(io));
+            handled = true;
+          }
+          break;
+        }
+        case F_DR_TA_1: { // Directory (126)
+          const auto io = reinterpret_cast<FileDirectory>(
+              CS101_ASDU_getElement(asdu, 0));
+          if (io) {
+            fc->handleDirectoryEntry(
+                InformationObject_getObjectAddress((InformationObject)io),
+                FileDirectory_getNOF(io),
+                FileDirectory_getLengthOfFile(io),
+                FileDirectory_getSOF(io),
+                CP56Time2a_toMsTimestamp(FileDirectory_getCreationTime(io)));
+            handled = true;
+          }
+          break;
+        }
+        case F_AF_NA_1: { // File ACK (124)
+          const auto io = reinterpret_cast<FileACK>(
+              CS101_ASDU_getElement(asdu, 0));
+          if (io) {
+            uint8_t afq = FileACK_getAFQ(io);
+            // Positive if AFQ is 1 (pos_file) or 3 (pos_section)
+            bool positive = (afq == 1 || afq == 3);
+            fc->handleFileAck(
+                FileACK_getNOF(io),
+                FileACK_getNameOfSection(io),
+                afq,
+                positive);
+            handled = true;
+          }
+          break;
+        }
+        default:
+          break;
+        }
+      }
+      // Return early for file transfer messages
+      return handled;
+    }
+
     const auto message =
         Remote::Message::IncomingMessage::create(asdu, parameters);
 
@@ -1195,6 +1747,8 @@ bool Connection::asduHandler(void *parameter, int address, CS101_ASDU asdu) {
     IEC60870_5_TypeID const type = message->getType();
     CS101_CauseOfTransmission const cot = message->getCauseOfTransmission();
     std::uint_fast16_t commonAddress = message->getCommonAddress();
+    fprintf(stderr, "[DEBUG] asduHandler type=%d, cot=%d, ca=%d\n", (int)type, (int)cot, (int)commonAddress);
+    fflush(stderr);
 
     std::shared_ptr<Object::Station> station{};
 

--- a/src/remote/Connection.h
+++ b/src/remote/Connection.h
@@ -35,6 +35,7 @@
 #include "module/Callback.h"
 #include "module/GilAwareMutex.h"
 #include "object/Station.h"
+#include "remote/FileClient.h"
 #include "types.h"
 
 namespace Remote {
@@ -405,6 +406,185 @@ public:
                   bool wait_for_response = true);
 
   /**
+   * @brief call a file on remote server (request file transfer)
+   * @param commonAddress station address
+   * @param ioa information object address of the file
+   * @param nof name of file
+   * @return success information
+   */
+  bool fileCall(std::uint_fast16_t commonAddress,
+                std::uint_fast32_t ioa,
+                std::uint_fast16_t nof);
+
+  /**
+   * @brief call a section on remote server (request section transfer)
+   * @param commonAddress station address
+   * @param ioa information object address of the file
+   * @param nof name of file
+   * @param nos name of section (section number)
+   * @return success information
+   */
+  bool sectionCall(std::uint_fast16_t commonAddress,
+                   std::uint_fast32_t ioa,
+                   std::uint_fast16_t nof,
+                   std::uint_fast8_t nos);
+
+  /**
+   * @brief send file/section acknowledgment
+   * @param commonAddress station address
+   * @param ioa information object address of the file
+   * @param nof name of file
+   * @param nos name of section (0 for file ack)
+   * @param afq acknowledge file qualifier (1=pos_file, 2=neg_file, 3=pos_section, 4=neg_section)
+   * @return success information
+   */
+  bool fileAck(std::uint_fast16_t commonAddress,
+               std::uint_fast32_t ioa,
+               std::uint_fast16_t nof,
+               std::uint_fast8_t nos,
+               std::uint_fast8_t afq);
+
+  /**
+   * @brief delete a file on remote server (F_SC_NA_1 with SCQ=4)
+   * WARNING: This is a destructive operation!
+   * @param commonAddress station address
+   * @param ioa information object address of the file to delete
+   * @return success information (whether command was sent)
+   */
+  bool deleteFile(std::uint_fast16_t commonAddress,
+                  std::uint_fast32_t ioa);
+
+  /**
+   * @brief download a file from remote server (blocking high-level API)
+   * @param commonAddress station address
+   * @param ioa information object address of the file
+   * @param timeout_ms maximum time to wait for transfer completion
+   * @return vector containing file data, empty on failure
+   */
+  std::vector<std::uint8_t> downloadFile(std::uint_fast16_t commonAddress,
+                                         std::uint_fast32_t ioa,
+                                         std::uint_fast32_t timeout_ms = 30000);
+
+  /**
+   * @brief send directory request to remote server (F_SC_NA_1 with COT=REQUEST)
+   * @param commonAddress station address
+   * @param ioa information object address (typically 0 for root)
+   * @return success information
+   */
+  bool directoryRequest(std::uint_fast16_t commonAddress,
+                        std::uint_fast32_t ioa);
+
+  /**
+   * @brief browse remote server directory (blocking high-level API)
+   * @param commonAddress station address
+   * @param ioa information object address (typically 0 for root)
+   * @param timeout_ms maximum time to wait for response
+   * @return vector of directory entries, empty on failure
+   */
+  std::vector<DirectoryEntry> browseDirectory(std::uint_fast16_t commonAddress,
+                                               std::uint_fast32_t ioa,
+                                               std::uint_fast32_t timeout_ms = 30000);
+
+  /**
+   * @brief upload a file to remote server (blocking high-level API)
+   * WARNING: This is a WRITE operation that modifies the remote device!
+   * @param commonAddress station address
+   * @param ioa information object address for the file
+   * @param nof name of file (1=transparent, 2=disturbance)
+   * @param data file data to upload
+   * @param timeout_ms maximum time to wait for acknowledgment
+   * @return true if upload completed successfully
+   */
+  bool uploadFile(std::uint_fast16_t commonAddress,
+                  std::uint_fast32_t ioa,
+                  std::uint_fast16_t nof,
+                  const std::vector<std::uint8_t>& data,
+                  std::uint_fast32_t timeout_ms = 30000);
+
+  /**
+   * @brief send F_FR_NA_1 (File Ready) to server for upload
+   * @param commonAddress station address
+   * @param ioa information object address
+   * @param nof name of file
+   * @param length total file length in bytes
+   * @return success information
+   */
+  bool sendFileReady(std::uint_fast16_t commonAddress,
+                     std::uint_fast32_t ioa,
+                     std::uint_fast16_t nof,
+                     std::uint_fast32_t length);
+
+  /**
+   * @brief send F_SR_NA_1 (Section Ready) to server for upload
+   * @param commonAddress station address
+   * @param ioa information object address
+   * @param nof name of file
+   * @param nos name of section (section number)
+   * @param length section length in bytes
+   * @return success information
+   */
+  bool sendSectionReady(std::uint_fast16_t commonAddress,
+                        std::uint_fast32_t ioa,
+                        std::uint_fast16_t nof,
+                        std::uint_fast8_t nos,
+                        std::uint_fast32_t length);
+
+  /**
+   * @brief send F_SG_NA_1 (File Segment) to server for upload
+   * @param commonAddress station address
+   * @param ioa information object address
+   * @param nof name of file
+   * @param nos name of section
+   * @param data pointer to segment data
+   * @param length length of segment data
+   * @return success information
+   */
+  bool sendSegment(std::uint_fast16_t commonAddress,
+                   std::uint_fast32_t ioa,
+                   std::uint_fast16_t nof,
+                   std::uint_fast8_t nos,
+                   const std::uint8_t* data,
+                   std::size_t length);
+
+  /**
+   * @brief send F_LS_NA_1 (Last Segment) to server for upload
+   * @param commonAddress station address
+   * @param ioa information object address
+   * @param nof name of file
+   * @param nos name of section
+   * @param lsq last segment qualifier
+   * @param checksum section checksum
+   * @return success information
+   */
+  bool sendLastSegment(std::uint_fast16_t commonAddress,
+                       std::uint_fast32_t ioa,
+                       std::uint_fast16_t nof,
+                       std::uint_fast8_t nos,
+                       std::uint_fast8_t lsq,
+                       std::uint_fast8_t checksum);
+
+  /**
+   * @brief query log with time range (F_SC_NB_1)
+   * @param commonAddress station address
+   * @param ioa information object address
+   * @param nof name of file (file type: 1=transparent, 2=disturbance, etc.)
+   * @param startTime_ms start of time range (milliseconds since epoch)
+   * @param stopTime_ms end of time range (milliseconds since epoch)
+   * @return success information
+   */
+  bool queryLog(std::uint_fast16_t commonAddress,
+                std::uint_fast32_t ioa,
+                std::uint_fast16_t nof,
+                std::uint_fast64_t startTime_ms,
+                std::uint_fast64_t stopTime_ms);
+
+  /**
+   * @brief get the file client instance for this connection
+   * @return shared pointer to the FileClient
+   */
+  std::shared_ptr<FileClient> getFileClient();
+
+  /**
    * @brief transmit a command to a remote server
    * @param point control point
    * @param cause reason for transmission
@@ -598,6 +778,9 @@ private:
   Module::Callback<void> py_onStateChange{
       "Connection.on_state_change",
       "(connection: c104.Connection, state: c104.ConnectionState) -> None"};
+
+  /// @brief file transfer client instance
+  std::shared_ptr<FileClient> fileClient{};
 
   /**
    * @brief update the connection state and trigger the on state change callback

--- a/src/remote/FileClient.cpp
+++ b/src/remote/FileClient.cpp
@@ -1,0 +1,820 @@
+/**
+ * Copyright 2020-2025 Fraunhofer Institute for Applied Information Technology
+ * FIT
+ *
+ * This file is part of iec104-python.
+ * iec104-python is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * iec104-python is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with iec104-python. If not, see <https://www.gnu.org/licenses/>.
+ *
+ *  See LICENSE file for the complete license text.
+ *
+ *
+ * @file FileClient.cpp
+ * @brief IEC 60870-5-104 file transfer client implementation
+ *
+ * @package iec104-python
+ * @namespace Remote
+ *
+ * @authors Martin Unkel <martin.unkel@fit.fraunhofer.de>
+ *
+ */
+
+#include "FileClient.h"
+#include "Connection.h"
+#include "module/ScopedGilRelease.h"
+
+using namespace Remote;
+using namespace std::chrono_literals;
+
+// SCQ (Select/Call Qualifier) values
+constexpr uint8_t SCQ_SELECT_FILE = 1;
+constexpr uint8_t SCQ_REQUEST_FILE = 2;
+constexpr uint8_t SCQ_DEACTIVATE_FILE = 3;
+constexpr uint8_t SCQ_REQUEST_SECTION = 6;
+constexpr uint8_t SCQ_DEACTIVATE_SECTION = 7;
+
+// AFQ (Acknowledge File Qualifier) values
+constexpr uint8_t AFQ_POS_ACK_FILE = 1;
+constexpr uint8_t AFQ_NEG_ACK_FILE = 2;
+constexpr uint8_t AFQ_POS_ACK_SECTION = 3;
+constexpr uint8_t AFQ_NEG_ACK_SECTION = 4;
+
+// LSQ (Last Segment Qualifier) values
+constexpr uint8_t LSQ_FILE_TRANSFER_WITHOUT_DEACT = 1;
+constexpr uint8_t LSQ_FILE_TRANSFER_WITH_DEACT = 2;
+constexpr uint8_t LSQ_SECTION_TRANSFER_WITHOUT_DEACT = 3;
+constexpr uint8_t LSQ_SECTION_TRANSFER_WITH_DEACT = 4;
+
+std::string Remote::FileClientState_toString(FileClientState state) {
+  switch (state) {
+  case FileClientState::IDLE:
+    return "IDLE";
+  case FileClientState::SELECTING:
+    return "SELECTING";
+  case FileClientState::WAITING_FILE_READY:
+    return "WAITING_FILE_READY";
+  case FileClientState::CALLING_FILE:
+    return "CALLING_FILE";
+  case FileClientState::WAITING_SECTION_READY:
+    return "WAITING_SECTION_READY";
+  case FileClientState::CALLING_SECTION:
+    return "CALLING_SECTION";
+  case FileClientState::RECEIVING_SEGMENTS:
+    return "RECEIVING_SEGMENTS";
+  case FileClientState::SENDING_SECTION_ACK:
+    return "SENDING_SECTION_ACK";
+  case FileClientState::SENDING_FILE_ACK:
+    return "SENDING_FILE_ACK";
+  case FileClientState::COMPLETE:
+    return "COMPLETE";
+  case FileClientState::ERROR:
+    return "ERROR";
+  case FileClientState::REQUESTING_DIRECTORY:
+    return "REQUESTING_DIRECTORY";
+  case FileClientState::RECEIVING_DIRECTORY:
+    return "RECEIVING_DIRECTORY";
+  // Upload states
+  case FileClientState::UPLOADING_FILE_READY:
+    return "UPLOADING_FILE_READY";
+  case FileClientState::UPLOADING_SECTION_READY:
+    return "UPLOADING_SECTION_READY";
+  case FileClientState::SENDING_SEGMENTS:
+    return "SENDING_SEGMENTS";
+  case FileClientState::SENDING_LAST_SEGMENT:
+    return "SENDING_LAST_SEGMENT";
+  case FileClientState::WAITING_FOR_ACK:
+    return "WAITING_FOR_ACK";
+  }
+  return "UNKNOWN";
+}
+
+std::string Remote::FileClientError_toString(FileClientError error) {
+  switch (error) {
+  case FileClientError::NONE:
+    return "NONE";
+  case FileClientError::TIMEOUT:
+    return "TIMEOUT";
+  case FileClientError::FILE_NOT_READY:
+    return "FILE_NOT_READY";
+  case FileClientError::SECTION_NOT_READY:
+    return "SECTION_NOT_READY";
+  case FileClientError::CHECKSUM_MISMATCH:
+    return "CHECKSUM_MISMATCH";
+  case FileClientError::PROTOCOL_ERROR:
+    return "PROTOCOL_ERROR";
+  case FileClientError::CONNECTION_LOST:
+    return "CONNECTION_LOST";
+  case FileClientError::ABORTED_BY_SERVER:
+    return "ABORTED_BY_SERVER";
+  case FileClientError::INVALID_RESPONSE:
+    return "INVALID_RESPONSE";
+  }
+  return "UNKNOWN";
+}
+
+FileClient::FileClient(std::weak_ptr<Connection> conn)
+    : connection(std::move(conn)) {
+  DEBUG_PRINT(Debug::Connection, "FileClient created");
+}
+
+FileClient::~FileClient() {
+  cancelTransfer();
+  DEBUG_PRINT(Debug::Connection, "FileClient destroyed");
+}
+
+FileClientState FileClient::getState() const { return state.load(); }
+
+FileClientError FileClient::getLastError() const { return lastError.load(); }
+
+bool FileClient::isTransferActive() const {
+  FileClientState s = state.load();
+  return s != FileClientState::IDLE && s != FileClientState::COMPLETE &&
+         s != FileClientState::ERROR;
+}
+
+void FileClient::cancelTransfer() {
+  std::lock_guard<Module::GilAwareMutex> lock(state_mutex);
+  if (isTransferActive()) {
+    setError(FileClientError::ABORTED_BY_SERVER);
+  }
+}
+
+void FileClient::setState(FileClientState newState) {
+  FileClientState prev = state.load();
+  if (prev != newState) {
+    state.store(newState);
+    DEBUG_PRINT(Debug::Connection, "FileClient state: " +
+                                       FileClientState_toString(prev) + " -> " +
+                                       FileClientState_toString(newState));
+    state_changed.notify_all();
+  }
+}
+
+void FileClient::setError(FileClientError error) {
+  lastError.store(error);
+  state.store(FileClientState::ERROR);
+  DEBUG_PRINT(Debug::Connection,
+              "FileClient error: " + FileClientError_toString(error));
+  state_changed.notify_all();
+}
+
+uint8_t FileClient::calculateChecksum(const uint8_t *data, size_t length) {
+  uint8_t sum = 0;
+  for (size_t i = 0; i < length; i++) {
+    sum += data[i];
+  }
+  return sum;
+}
+
+bool FileClient::sendFileCommand(uint8_t scq, uint8_t nos) {
+  auto conn = connection.lock();
+  if (!conn || !conn->isOpen()) {
+    setError(FileClientError::CONNECTION_LOST);
+    return false;
+  }
+
+  bool result = false;
+  switch (scq) {
+  case SCQ_SELECT_FILE:
+    result = conn->fileSelect(currentCA, currentIOA, false);
+    break;
+  case SCQ_REQUEST_FILE:
+    result = conn->fileCall(currentCA, currentIOA, currentNOF);
+    break;
+  case SCQ_REQUEST_SECTION:
+    result = conn->sectionCall(currentCA, currentIOA, currentNOF, nos);
+    break;
+  default:
+    DEBUG_PRINT(Debug::Connection, "FileClient: Unknown SCQ=" + std::to_string(scq));
+    return false;
+  }
+
+  DEBUG_PRINT(Debug::Connection, "FileClient sendFileCommand SCQ=" +
+                                     std::to_string(scq) +
+                                     " NOS=" + std::to_string(nos) +
+                                     " Result=" + std::to_string(result));
+  return result;
+}
+
+bool FileClient::sendFileAck(uint8_t afq, uint8_t nos) {
+  auto conn = connection.lock();
+  if (!conn || !conn->isOpen()) {
+    setError(FileClientError::CONNECTION_LOST);
+    return false;
+  }
+
+  bool result = conn->fileAck(currentCA, currentIOA, currentNOF, nos, afq);
+
+  DEBUG_PRINT(Debug::Connection, "FileClient sendFileAck AFQ=" +
+                                     std::to_string(afq) +
+                                     " NOS=" + std::to_string(nos) +
+                                     " Result=" + std::to_string(result));
+  return result;
+}
+
+std::vector<uint8_t> FileClient::downloadFile(uint16_t commonAddress,
+                                              uint32_t ioa,
+                                              uint32_t timeout_ms) {
+  Module::ScopedGilRelease const scoped("FileClient.downloadFile");
+
+  // Check if already transferring
+  if (isTransferActive()) {
+    DEBUG_PRINT(Debug::Connection,
+                "FileClient: Transfer already in progress");
+    return {};
+  }
+
+  auto conn = connection.lock();
+  if (!conn || !conn->isOpen()) {
+    DEBUG_PRINT(Debug::Connection, "FileClient: Connection not available");
+    return {};
+  }
+
+  // Initialize transfer state
+  {
+    std::lock_guard<Module::GilAwareMutex> lock(state_mutex);
+    currentCA = commonAddress;
+    currentIOA = ioa;
+    currentNOF = CS101_NOF_TRANSPARENT_FILE;
+    currentSection = 1;  // Section numbers are 1-indexed per IEC 60870-5-7
+    expectedFileSize = 0;
+    expectedSectionSize = 0;
+    runningChecksum = 0;
+    fileData.clear();
+    sectionData.clear();
+    lastError.store(FileClientError::NONE);
+  }
+
+  auto deadline =
+      std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms);
+
+  // Step 1: Send SELECT (SCQ=1)
+  DEBUG_PRINT(Debug::Connection,
+              "FileClient: Step 1 - Sending SELECT for CA=" +
+                  std::to_string(commonAddress) +
+                  " IOA=" + std::to_string(ioa));
+
+  setState(FileClientState::SELECTING);
+
+  // Use the existing fileSelect method on Connection
+  if (!conn->fileSelect(commonAddress, ioa, false)) {
+    setError(FileClientError::PROTOCOL_ERROR);
+    return {};
+  }
+
+  // Wait for F_FR_NA_1 (File Ready)
+  {
+    std::unique_lock<Module::GilAwareMutex> lock(state_mutex);
+    while (state.load() == FileClientState::SELECTING) {
+      if (state_changed.wait_until(lock, deadline) ==
+          std::cv_status::timeout) {
+        setError(FileClientError::TIMEOUT);
+        return {};
+      }
+    }
+  }
+
+  // Check if we got file ready
+  if (state.load() == FileClientState::ERROR) {
+    return {};
+  }
+
+  // Step 2: Send CALL (SCQ=2) to request the file
+  DEBUG_PRINT(Debug::Connection, "FileClient: Step 2 - Sending CALL FILE");
+  setState(FileClientState::CALLING_FILE);
+
+  if (!sendFileCommand(SCQ_REQUEST_FILE, 0)) {
+    return {};
+  }
+
+  // Main transfer loop
+  while (state.load() != FileClientState::COMPLETE &&
+         state.load() != FileClientState::ERROR) {
+
+    std::unique_lock<Module::GilAwareMutex> lock(state_mutex);
+    FileClientState currentState = state.load();
+
+    // Wait for next state change or timeout
+    if (state_changed.wait_until(lock, deadline) == std::cv_status::timeout) {
+      setError(FileClientError::TIMEOUT);
+      return {};
+    }
+
+    currentState = state.load();
+
+    switch (currentState) {
+    case FileClientState::WAITING_SECTION_READY:
+      // Wait for F_SR_NA_1
+      break;
+
+    case FileClientState::CALLING_SECTION:
+      // Send SCQ=6 to request section data
+      lock.unlock();
+      if (!sendFileCommand(SCQ_REQUEST_SECTION, currentSection)) {
+        return {};
+      }
+      setState(FileClientState::RECEIVING_SEGMENTS);
+      break;
+
+    case FileClientState::RECEIVING_SEGMENTS:
+      // Wait for F_SG_NA_1 segments
+      break;
+
+    case FileClientState::SENDING_SECTION_ACK:
+      // Send positive acknowledgment for section
+      lock.unlock();
+      if (!sendFileAck(AFQ_POS_ACK_SECTION, currentSection)) {
+        return {};
+      }
+      // Move to next section or complete
+      if (currentSection < 255) {
+        currentSection++;
+        setState(FileClientState::WAITING_SECTION_READY);
+      } else {
+        setState(FileClientState::SENDING_FILE_ACK);
+      }
+      break;
+
+    case FileClientState::SENDING_FILE_ACK:
+      // Send positive acknowledgment for complete file
+      lock.unlock();
+      if (!sendFileAck(AFQ_POS_ACK_FILE, 0)) {
+        return {};
+      }
+      setState(FileClientState::COMPLETE);
+      break;
+
+    default:
+      break;
+    }
+  }
+
+  if (state.load() == FileClientState::COMPLETE) {
+    DEBUG_PRINT(Debug::Connection,
+                "FileClient: Transfer complete, " +
+                    std::to_string(fileData.size()) + " bytes");
+    setState(FileClientState::IDLE);
+    return fileData;
+  }
+
+  DEBUG_PRINT(Debug::Connection,
+              "FileClient: Transfer failed: " +
+                  FileClientError_toString(lastError.load()));
+  setState(FileClientState::IDLE);
+  return {};
+}
+
+void FileClient::handleFileReady(uint16_t nof, uint32_t lengthOfFile,
+                                 uint8_t frq, bool positive) {
+  std::lock_guard<Module::GilAwareMutex> lock(state_mutex);
+
+  DEBUG_PRINT(Debug::Connection,
+              "FileClient: F_FR_NA_1 received - NOF=" + std::to_string(nof) +
+                  " Length=" + std::to_string(lengthOfFile) +
+                  " Positive=" + std::to_string(positive));
+
+  if (state.load() != FileClientState::SELECTING) {
+    DEBUG_PRINT(Debug::Connection,
+                "FileClient: Unexpected F_FR_NA_1 in state " +
+                    FileClientState_toString(state.load()));
+    return;
+  }
+
+  if (!positive) {
+    setError(FileClientError::FILE_NOT_READY);
+    return;
+  }
+
+  currentNOF = nof;
+  expectedFileSize = lengthOfFile;
+  fileData.reserve(lengthOfFile);
+
+  setState(FileClientState::CALLING_FILE);
+}
+
+void FileClient::handleSectionReady(uint16_t nof, uint8_t nos,
+                                    uint32_t lengthOfSection, uint8_t srq,
+                                    bool notReady) {
+  std::lock_guard<Module::GilAwareMutex> lock(state_mutex);
+
+  DEBUG_PRINT(Debug::Connection,
+              "FileClient: F_SR_NA_1 received - NOF=" + std::to_string(nof) +
+                  " NOS=" + std::to_string(nos) +
+                  " Length=" + std::to_string(lengthOfSection) +
+                  " NotReady=" + std::to_string(notReady));
+
+  FileClientState currentState = state.load();
+  if (currentState != FileClientState::CALLING_FILE &&
+      currentState != FileClientState::WAITING_SECTION_READY) {
+    DEBUG_PRINT(Debug::Connection,
+                "FileClient: Unexpected F_SR_NA_1 in state " +
+                    FileClientState_toString(currentState));
+    return;
+  }
+
+  if (notReady) {
+    setError(FileClientError::SECTION_NOT_READY);
+    return;
+  }
+
+  currentSection = nos;
+  expectedSectionSize = lengthOfSection;
+  sectionData.clear();
+  sectionData.reserve(lengthOfSection);
+  runningChecksum = 0;
+
+  setState(FileClientState::CALLING_SECTION);
+}
+
+void FileClient::handleSegment(uint16_t nof, uint8_t nos, const uint8_t *data,
+                               uint8_t length) {
+  std::lock_guard<Module::GilAwareMutex> lock(state_mutex);
+
+  DEBUG_PRINT(Debug::Connection,
+              "FileClient: F_SG_NA_1 received - NOF=" + std::to_string(nof) +
+                  " NOS=" + std::to_string(nos) +
+                  " Length=" + std::to_string(length));
+
+  if (state.load() != FileClientState::RECEIVING_SEGMENTS) {
+    DEBUG_PRINT(Debug::Connection,
+                "FileClient: Unexpected F_SG_NA_1 in state " +
+                    FileClientState_toString(state.load()));
+    return;
+  }
+
+  // Append data to section buffer
+  sectionData.insert(sectionData.end(), data, data + length);
+
+  // Update running checksum
+  runningChecksum += calculateChecksum(data, length);
+
+  DEBUG_PRINT(Debug::Connection,
+              "FileClient: Section progress: " +
+                  std::to_string(sectionData.size()) + "/" +
+                  std::to_string(expectedSectionSize) + " bytes");
+}
+
+void FileClient::handleLastSegmentOrSection(uint16_t nof, uint8_t nos,
+                                            uint8_t lsq, uint8_t chs) {
+  std::lock_guard<Module::GilAwareMutex> lock(state_mutex);
+
+  DEBUG_PRINT(Debug::Connection,
+              "FileClient: F_LS_NA_1 received - NOF=" + std::to_string(nof) +
+                  " NOS=" + std::to_string(nos) +
+                  " LSQ=" + std::to_string(lsq) +
+                  " CHS=" + std::to_string(chs));
+
+  if (state.load() != FileClientState::RECEIVING_SEGMENTS) {
+    DEBUG_PRINT(Debug::Connection,
+                "FileClient: Unexpected F_LS_NA_1 in state " +
+                    FileClientState_toString(state.load()));
+    return;
+  }
+
+  // Validate checksum
+  if (runningChecksum != chs) {
+    DEBUG_PRINT(Debug::Connection,
+                "FileClient: Checksum mismatch - Expected=" +
+                    std::to_string(chs) +
+                    " Got=" + std::to_string(runningChecksum));
+    setError(FileClientError::CHECKSUM_MISMATCH);
+    return;
+  }
+
+  // Append section data to file
+  fileData.insert(fileData.end(), sectionData.begin(), sectionData.end());
+
+  DEBUG_PRINT(Debug::Connection,
+              "FileClient: Section " + std::to_string(nos) + " complete, " +
+                  "Total: " + std::to_string(fileData.size()) + "/" +
+                  std::to_string(expectedFileSize) + " bytes");
+
+  // Check LSQ to determine next action
+  switch (lsq) {
+  case LSQ_SECTION_TRANSFER_WITHOUT_DEACT:
+    // Section complete, more sections to come
+    setState(FileClientState::SENDING_SECTION_ACK);
+    break;
+
+  case LSQ_SECTION_TRANSFER_WITH_DEACT:
+    // Server aborted section transfer
+    DEBUG_PRINT(Debug::Connection,
+                "FileClient: Server aborted section transfer (LSQ=4)");
+    setError(FileClientError::ABORTED_BY_SERVER);
+    break;
+
+  case LSQ_FILE_TRANSFER_WITHOUT_DEACT:
+    // Last section of file, transfer complete
+    setState(FileClientState::SENDING_FILE_ACK);
+    break;
+
+  case LSQ_FILE_TRANSFER_WITH_DEACT:
+    // Server aborted file transfer
+    DEBUG_PRINT(Debug::Connection,
+                "FileClient: Server aborted file transfer (LSQ=2)");
+    setError(FileClientError::ABORTED_BY_SERVER);
+    break;
+
+  default:
+    DEBUG_PRINT(Debug::Connection,
+                "FileClient: Unknown LSQ value: " + std::to_string(lsq));
+    // Assume section complete, continue cautiously
+    setState(FileClientState::SENDING_SECTION_ACK);
+    break;
+  }
+}
+
+std::vector<DirectoryEntry> FileClient::browseDirectory(uint16_t commonAddress,
+                                                        uint32_t ioa,
+                                                        uint32_t timeout_ms) {
+  Module::ScopedGilRelease const scoped("FileClient.browseDirectory");
+
+  // Check if already transferring
+  if (isTransferActive()) {
+    DEBUG_PRINT(Debug::Connection,
+                "FileClient: Transfer already in progress");
+    return {};
+  }
+
+  auto conn = connection.lock();
+  if (!conn || !conn->isOpen()) {
+    DEBUG_PRINT(Debug::Connection, "FileClient: Connection not available");
+    return {};
+  }
+
+  // Initialize directory browsing state
+  {
+    std::lock_guard<Module::GilAwareMutex> lock(state_mutex);
+    currentCA = commonAddress;
+    currentIOA = ioa;
+    directoryEntries.clear();
+    directoryComplete = false;
+    lastError.store(FileClientError::NONE);
+  }
+
+  auto deadline =
+      std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms);
+
+  // Send directory request (F_SC_NA_1 with COT=REQUEST)
+  DEBUG_PRINT(Debug::Connection,
+              "FileClient: Sending directory request for CA=" +
+                  std::to_string(commonAddress) +
+                  " IOA=" + std::to_string(ioa));
+
+  setState(FileClientState::REQUESTING_DIRECTORY);
+
+  if (!conn->directoryRequest(commonAddress, ioa)) {
+    setError(FileClientError::PROTOCOL_ERROR);
+    return {};
+  }
+
+  setState(FileClientState::RECEIVING_DIRECTORY);
+
+  // Wait for F_DR_TA_1 responses until LFD=1 (last file)
+  {
+    std::unique_lock<Module::GilAwareMutex> lock(state_mutex);
+    while (!directoryComplete && state.load() != FileClientState::ERROR) {
+      if (state_changed.wait_until(lock, deadline) ==
+          std::cv_status::timeout) {
+        setError(FileClientError::TIMEOUT);
+        break;
+      }
+    }
+  }
+
+  if (state.load() == FileClientState::ERROR) {
+    DEBUG_PRINT(Debug::Connection,
+                "FileClient: Directory request failed: " +
+                    FileClientError_toString(lastError.load()));
+    setState(FileClientState::IDLE);
+    return {};
+  }
+
+  DEBUG_PRINT(Debug::Connection,
+              "FileClient: Directory complete, " +
+                  std::to_string(directoryEntries.size()) + " entries");
+
+  std::vector<DirectoryEntry> result = std::move(directoryEntries);
+  directoryEntries.clear();
+  directoryComplete = false;
+  setState(FileClientState::IDLE);
+
+  return result;
+}
+
+void FileClient::handleDirectoryEntry(uint32_t ioa, uint16_t nof,
+                                      uint32_t lengthOfFile, uint8_t sof,
+                                      uint64_t creationTime) {
+  std::lock_guard<Module::GilAwareMutex> lock(state_mutex);
+
+  DEBUG_PRINT(Debug::Connection,
+              "FileClient: F_DR_TA_1 received - IOA=" + std::to_string(ioa) +
+                  " NOF=" + std::to_string(nof) +
+                  " Length=" + std::to_string(lengthOfFile) +
+                  " SOF=0x" + std::to_string(sof));
+
+  FileClientState currentState = state.load();
+  if (currentState != FileClientState::RECEIVING_DIRECTORY &&
+      currentState != FileClientState::REQUESTING_DIRECTORY) {
+    DEBUG_PRINT(Debug::Connection,
+                "FileClient: Unexpected F_DR_TA_1 in state " +
+                    FileClientState_toString(currentState));
+    return;
+  }
+
+  // Transition to receiving state if we were requesting
+  if (currentState == FileClientState::REQUESTING_DIRECTORY) {
+    state.store(FileClientState::RECEIVING_DIRECTORY);
+  }
+
+  // Parse SOF (Status Of File) bits
+  // Bit 5 (0x20): LFD - Last File of Directory
+  // Bit 6 (0x40): FOR - File OR directory (0=file, 1=directory)
+  // Bit 7 (0x80): FA - File Active (being transferred)
+  bool lastFile = (sof & 0x20) != 0;
+  bool isDirectory = (sof & 0x40) != 0;
+  bool fileActive = (sof & 0x80) != 0;
+
+  DirectoryEntry entry;
+  entry.ioa = ioa;
+  entry.nof = nof;
+  entry.lengthOfFile = lengthOfFile;
+  entry.sof = sof;
+  entry.lastFile = lastFile;
+  entry.isDirectory = isDirectory;
+  entry.fileActive = fileActive;
+  entry.creationTime = creationTime;
+
+  directoryEntries.push_back(entry);
+
+  DEBUG_PRINT(Debug::Connection,
+              "FileClient: Directory entry - IOA=" + std::to_string(ioa) +
+                  " Size=" + std::to_string(lengthOfFile) +
+                  " IsDir=" + std::to_string(isDirectory) +
+                  " LastFile=" + std::to_string(lastFile));
+
+  if (lastFile) {
+    directoryComplete = true;
+    setState(FileClientState::COMPLETE);
+  }
+}
+
+// Maximum segment size per IEC 60870-5-104
+constexpr size_t MAX_SEGMENT_SIZE = 240;
+
+bool FileClient::uploadFile(uint16_t commonAddress, uint32_t ioa, uint16_t nof,
+                            const std::vector<uint8_t>& data,
+                            uint32_t timeout_ms) {
+  Module::ScopedGilRelease const scoped("FileClient.uploadFile");
+
+  if (isTransferActive()) {
+    DEBUG_PRINT(Debug::Connection, "FileClient: Transfer already in progress");
+    return false;
+  }
+
+  auto conn = connection.lock();
+  if (!conn || !conn->isOpen()) {
+    DEBUG_PRINT(Debug::Connection, "FileClient: Connection not available");
+    return false;
+  }
+
+  // Initialize upload state
+  {
+    std::lock_guard<Module::GilAwareMutex> lock(state_mutex);
+    currentCA = commonAddress;
+    currentIOA = ioa;
+    currentNOF = nof;
+    uploadData = data;
+    uploadOffset = 0;
+    currentSection = 1;
+    lastError.store(FileClientError::NONE);
+  }
+
+  auto deadline =
+      std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms);
+
+  DEBUG_PRINT(Debug::Connection,
+              "FileClient: Upload starting - CA=" + std::to_string(commonAddress) +
+              " IOA=" + std::to_string(ioa) + " NOF=" + std::to_string(nof) +
+              " Size=" + std::to_string(data.size()));
+
+  // Step 1: Send F_FR_NA_1 (File Ready)
+  setState(FileClientState::UPLOADING_FILE_READY);
+  if (!conn->sendFileReady(commonAddress, ioa, nof, data.size())) {
+    setError(FileClientError::PROTOCOL_ERROR);
+    return false;
+  }
+
+  // Step 2: Send F_SR_NA_1 (Section Ready)
+  setState(FileClientState::UPLOADING_SECTION_READY);
+  if (!conn->sendSectionReady(commonAddress, ioa, nof, currentSection, data.size())) {
+    setError(FileClientError::PROTOCOL_ERROR);
+    return false;
+  }
+
+  // Step 3: Send segments
+  setState(FileClientState::SENDING_SEGMENTS);
+  size_t offset = 0;
+  uint8_t sectionChecksum = 0;
+
+  while (offset < data.size()) {
+    size_t remaining = data.size() - offset;
+    size_t segmentSize = std::min(remaining, MAX_SEGMENT_SIZE);
+
+    // Calculate checksum for this segment
+    for (size_t i = 0; i < segmentSize; i++) {
+      sectionChecksum += data[offset + i];
+    }
+
+    if (!conn->sendSegment(commonAddress, ioa, nof, currentSection,
+                           &data[offset], segmentSize)) {
+      setError(FileClientError::PROTOCOL_ERROR);
+      return false;
+    }
+
+    DEBUG_PRINT(Debug::Connection,
+                "FileClient: Sent segment " + std::to_string(offset) + "-" +
+                std::to_string(offset + segmentSize) + " / " +
+                std::to_string(data.size()));
+
+    offset += segmentSize;
+  }
+
+  // Step 4: Send F_LS_NA_1 (Last Segment) with checksum
+  setState(FileClientState::SENDING_LAST_SEGMENT);
+  if (!conn->sendLastSegment(commonAddress, ioa, nof, currentSection,
+                             LSQ_FILE_TRANSFER_WITHOUT_DEACT, sectionChecksum)) {
+    setError(FileClientError::PROTOCOL_ERROR);
+    return false;
+  }
+
+  DEBUG_PRINT(Debug::Connection,
+              "FileClient: Last segment sent, checksum=" +
+              std::to_string(sectionChecksum));
+
+  // Step 5: Wait for F_AF_NA_1 acknowledgment
+  setState(FileClientState::WAITING_FOR_ACK);
+  {
+    std::unique_lock<Module::GilAwareMutex> lock(state_mutex);
+    while (state.load() == FileClientState::WAITING_FOR_ACK) {
+      if (state_changed.wait_until(lock, deadline) == std::cv_status::timeout) {
+        setError(FileClientError::TIMEOUT);
+        return false;
+      }
+    }
+  }
+
+  bool success = state.load() == FileClientState::COMPLETE;
+
+  if (success) {
+    DEBUG_PRINT(Debug::Connection,
+                "FileClient: Upload complete, " + std::to_string(data.size()) +
+                " bytes uploaded");
+  } else {
+    DEBUG_PRINT(Debug::Connection,
+                "FileClient: Upload failed: " +
+                FileClientError_toString(lastError.load()));
+  }
+
+  setState(FileClientState::IDLE);
+  return success;
+}
+
+void FileClient::handleFileAck(uint16_t nof, uint8_t nos, uint8_t afq,
+                               bool positive) {
+  std::lock_guard<Module::GilAwareMutex> lock(state_mutex);
+
+  DEBUG_PRINT(Debug::Connection,
+              "FileClient: F_AF_NA_1 received - NOF=" + std::to_string(nof) +
+              " NOS=" + std::to_string(nos) + " AFQ=" + std::to_string(afq) +
+              " Positive=" + std::to_string(positive));
+
+  FileClientState currentState = state.load();
+  if (currentState != FileClientState::WAITING_FOR_ACK) {
+    DEBUG_PRINT(Debug::Connection,
+                "FileClient: Unexpected F_AF_NA_1 in state " +
+                FileClientState_toString(currentState));
+    return;
+  }
+
+  // AFQ values:
+  // 1 = positive acknowledge of file (AFQ_POS_ACK_FILE)
+  // 2 = negative acknowledge of file (AFQ_NEG_ACK_FILE)
+  // 3 = positive acknowledge of section (AFQ_POS_ACK_SECTION)
+  // 4 = negative acknowledge of section (AFQ_NEG_ACK_SECTION)
+  if (positive && (afq == AFQ_POS_ACK_FILE || afq == AFQ_POS_ACK_SECTION)) {
+    setState(FileClientState::COMPLETE);
+  } else {
+    setError(FileClientError::ABORTED_BY_SERVER);
+  }
+}

--- a/src/remote/FileClient.h
+++ b/src/remote/FileClient.h
@@ -1,0 +1,395 @@
+/**
+ * Copyright 2020-2025 Fraunhofer Institute for Applied Information Technology
+ * FIT
+ *
+ * This file is part of iec104-python.
+ * iec104-python is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * iec104-python is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with iec104-python. If not, see <https://www.gnu.org/licenses/>.
+ *
+ *  See LICENSE file for the complete license text.
+ *
+ *
+ * @file FileClient.h
+ * @brief IEC 60870-5-104 file transfer client implementation
+ *
+ * @package iec104-python
+ * @namespace Remote
+ *
+ * @authors Martin Unkel <martin.unkel@fit.fraunhofer.de>
+ *
+ */
+
+#ifndef C104_REMOTE_FILECLIENT_H
+#define C104_REMOTE_FILECLIENT_H
+
+#include "module/GilAwareMutex.h"
+#include "types.h"
+#include <condition_variable>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <vector>
+
+namespace Remote {
+
+class Connection;
+
+/**
+ * @brief Directory entry from F_DR_TA_1 response
+ */
+struct DirectoryEntry {
+  uint32_t ioa;           ///< Information Object Address (file identifier)
+  uint16_t nof;           ///< Name Of File (file type: 1=transparent, 2=disturbance)
+  uint32_t lengthOfFile;  ///< File size in bytes
+  uint8_t sof;            ///< Status Of File byte (raw)
+  bool lastFile;          ///< LFD flag: Last File of Directory
+  bool isDirectory;       ///< FOR flag: File OR directory (0=file, 1=dir)
+  bool fileActive;        ///< FA flag: File is being transferred
+  uint64_t creationTime;  ///< File creation timestamp (milliseconds since epoch)
+};
+
+/**
+ * @brief File transfer state machine states
+ */
+enum class FileClientState {
+  IDLE,                  ///< No transfer in progress
+  // Download states
+  SELECTING,             ///< Sent F_SC_NA_1 (SCQ=1), waiting for F_FR_NA_1
+  WAITING_FILE_READY,    ///< Waiting for file ready response
+  CALLING_FILE,          ///< Sent F_SC_NA_1 (SCQ=2), waiting for F_SR_NA_1
+  WAITING_SECTION_READY, ///< Waiting for section ready response
+  CALLING_SECTION,       ///< Sent F_SC_NA_1 (SCQ=6), waiting for F_SG_NA_1
+  RECEIVING_SEGMENTS,    ///< Receiving file segments
+  SENDING_SECTION_ACK,   ///< Sending F_AF_NA_1 for section
+  SENDING_FILE_ACK,      ///< Sending F_AF_NA_1 for file
+  COMPLETE,              ///< Transfer completed successfully
+  ERROR,                 ///< Transfer failed
+  // Directory browsing states
+  REQUESTING_DIRECTORY,  ///< Sent directory request, waiting for F_DR_TA_1
+  RECEIVING_DIRECTORY,   ///< Receiving F_DR_TA_1 entries
+  // Upload states (control direction)
+  UPLOADING_FILE_READY,    ///< Sending F_FR_NA_1 (File Ready) to server
+  UPLOADING_SECTION_READY, ///< Sending F_SR_NA_1 (Section Ready) to server
+  SENDING_SEGMENTS,        ///< Sending F_SG_NA_1 segments to server
+  SENDING_LAST_SEGMENT,    ///< Sending F_LS_NA_1 with checksum
+  WAITING_FOR_ACK          ///< Waiting for F_AF_NA_1 acknowledgment from server
+};
+
+/**
+ * @brief File transfer error codes
+ */
+enum class FileClientError {
+  NONE,                ///< No error
+  TIMEOUT,             ///< Operation timed out
+  FILE_NOT_READY,      ///< Server reported file not ready
+  SECTION_NOT_READY,   ///< Server reported section not ready
+  CHECKSUM_MISMATCH,   ///< Checksum validation failed
+  PROTOCOL_ERROR,      ///< Protocol violation
+  CONNECTION_LOST,     ///< Connection lost during transfer
+  ABORTED_BY_SERVER,   ///< Transfer aborted by server
+  INVALID_RESPONSE     ///< Unexpected response from server
+};
+
+/**
+ * @brief Convert FileClientState to string representation
+ */
+std::string FileClientState_toString(FileClientState state);
+
+/**
+ * @brief Convert FileClientError to string representation
+ */
+std::string FileClientError_toString(FileClientError error);
+
+/**
+ * @brief IEC 60870-5-104 file transfer client
+ *
+ * Implements the client-side file transfer protocol according to IEC 60870-5-7.
+ * Handles the complete file download state machine including:
+ * - File selection (F_SC_NA_1 with SCQ=1)
+ * - File call (F_SC_NA_1 with SCQ=2)
+ * - Section call (F_SC_NA_1 with SCQ=6)
+ * - Segment reception (F_SG_NA_1)
+ * - Last segment handling (F_LS_NA_1)
+ * - Acknowledgments (F_AF_NA_1)
+ */
+class FileClient : public std::enable_shared_from_this<FileClient> {
+public:
+  // noncopyable
+  FileClient(const FileClient &) = delete;
+  FileClient &operator=(const FileClient &) = delete;
+
+  /**
+   * @brief Create a new FileClient instance
+   * @param connection The connection to use for file transfer
+   * @return Shared pointer to the new FileClient instance
+   */
+  [[nodiscard]] static std::shared_ptr<FileClient>
+  create(std::weak_ptr<Connection> connection) {
+    return std::shared_ptr<FileClient>(new FileClient(std::move(connection)));
+  }
+
+  ~FileClient();
+
+  /**
+   * @brief Download a file from the remote server (blocking)
+   *
+   * This method implements the complete file download protocol:
+   * 1. Send F_SC_NA_1 (SCQ=1) to select the file
+   * 2. Wait for F_FR_NA_1 (file ready) response
+   * 3. Send F_SC_NA_1 (SCQ=2) to request the file
+   * 4. For each section:
+   *    a. Wait for F_SR_NA_1 (section ready)
+   *    b. Send F_SC_NA_1 (SCQ=6) to request section data
+   *    c. Receive F_SG_NA_1 segments
+   *    d. Receive F_LS_NA_1 (last segment) with checksum
+   *    e. Validate checksum and send F_AF_NA_1 acknowledgment
+   * 5. Send final F_AF_NA_1 to acknowledge complete file
+   *
+   * @param commonAddress Station common address
+   * @param ioa Information object address of the file
+   * @param timeout_ms Maximum time to wait for complete transfer
+   * @return Vector containing the file data, empty on failure
+   */
+  std::vector<uint8_t> downloadFile(uint16_t commonAddress, uint32_t ioa,
+                                    uint32_t timeout_ms = 30000);
+
+  /**
+   * @brief Browse remote directory (blocking)
+   *
+   * Sends F_SC_NA_1 with COT=REQUEST to request directory listing.
+   * Waits for F_DR_TA_1 responses until last entry (LFD=1) is received.
+   *
+   * @param commonAddress Station common address
+   * @param ioa Information object address (typically 0 for root directory)
+   * @param timeout_ms Maximum time to wait for complete directory
+   * @return Vector of directory entries, empty on failure
+   */
+  std::vector<DirectoryEntry> browseDirectory(uint16_t commonAddress,
+                                              uint32_t ioa,
+                                              uint32_t timeout_ms = 30000);
+
+  /**
+   * @brief Upload a file to the remote server (blocking)
+   *
+   * This method implements the complete file upload protocol (control direction):
+   * 1. Send F_FR_NA_1 (File Ready) with file length
+   * 2. Send F_SR_NA_1 (Section Ready) with section length
+   * 3. Send F_SG_NA_1 segments (max 240 bytes each)
+   * 4. Send F_LS_NA_1 (Last Segment) with checksum
+   * 5. Wait for F_AF_NA_1 acknowledgment from server
+   *
+   * WARNING: This is a WRITE operation that modifies the remote device!
+   *
+   * @param commonAddress Station common address
+   * @param ioa Information object address for the file
+   * @param nof Name of file (1=transparent, 2=disturbance)
+   * @param data File data to upload
+   * @param timeout_ms Maximum time to wait for acknowledgment
+   * @return True if upload completed successfully
+   */
+  bool uploadFile(uint16_t commonAddress, uint32_t ioa, uint16_t nof,
+                  const std::vector<uint8_t>& data, uint32_t timeout_ms = 30000);
+
+  /**
+   * @brief Get the current state of the file transfer
+   * @return Current FileClientState
+   */
+  FileClientState getState() const;
+
+  /**
+   * @brief Get the last error that occurred
+   * @return Last FileClientError
+   */
+  FileClientError getLastError() const;
+
+  /**
+   * @brief Check if a transfer is currently in progress
+   * @return True if transfer is active
+   */
+  bool isTransferActive() const;
+
+  /**
+   * @brief Cancel any ongoing transfer
+   */
+  void cancelTransfer();
+
+  // ASDU handlers - called by Connection::asduHandler
+
+  /**
+   * @brief Handle F_FR_NA_1 (File Ready) response
+   * @param nof Name of file
+   * @param lengthOfFile Total file size in bytes
+   * @param frq File ready qualifier
+   * @param positive True if file is ready
+   */
+  void handleFileReady(uint16_t nof, uint32_t lengthOfFile, uint8_t frq,
+                       bool positive);
+
+  /**
+   * @brief Handle F_SR_NA_1 (Section Ready) response
+   * @param nof Name of file
+   * @param nos Name of section (section number)
+   * @param lengthOfSection Section size in bytes
+   * @param srq Section ready qualifier
+   * @param notReady True if section is not ready
+   */
+  void handleSectionReady(uint16_t nof, uint8_t nos, uint32_t lengthOfSection,
+                          uint8_t srq, bool notReady);
+
+  /**
+   * @brief Handle F_SG_NA_1 (File Segment) message
+   * @param nof Name of file
+   * @param nos Name of section (section number)
+   * @param data Pointer to segment data
+   * @param length Length of segment data
+   */
+  void handleSegment(uint16_t nof, uint8_t nos, const uint8_t *data,
+                     uint8_t length);
+
+  /**
+   * @brief Handle F_LS_NA_1 (Last Segment) message
+   * @param nof Name of file
+   * @param nos Name of section (section number)
+   * @param lsq Last segment qualifier
+   * @param chs Checksum
+   */
+  void handleLastSegmentOrSection(uint16_t nof, uint8_t nos, uint8_t lsq,
+                                  uint8_t chs);
+
+  /**
+   * @brief Handle F_DR_TA_1 (Directory) response
+   * @param ioa Information Object Address of the file
+   * @param nof Name of file (file type)
+   * @param lengthOfFile File size in bytes
+   * @param sof Status of File byte (contains LFD, FOR, FA flags)
+   * @param creationTime File creation timestamp in milliseconds
+   */
+  void handleDirectoryEntry(uint32_t ioa, uint16_t nof, uint32_t lengthOfFile,
+                            uint8_t sof, uint64_t creationTime);
+
+  /**
+   * @brief Handle F_AF_NA_1 (File Acknowledgment) response
+   *
+   * Called when server acknowledges a file/section during upload.
+   *
+   * @param nof Name of file
+   * @param nos Name of section (section number)
+   * @param afq Acknowledge File Qualifier (1=pos_file, 2=neg_file, 3=pos_section, 4=neg_section)
+   * @param positive True if positive acknowledgment
+   */
+  void handleFileAck(uint16_t nof, uint8_t nos, uint8_t afq, bool positive);
+
+private:
+  /**
+   * @brief Private constructor
+   * @param connection The connection to use
+   */
+  explicit FileClient(std::weak_ptr<Connection> connection);
+
+  /**
+   * @brief Send F_SC_NA_1 with specified SCQ value
+   * @param scq Select/Call Qualifier (1=select, 2=call, 6=call_section)
+   * @param nos Name of section (for SCQ=6)
+   * @return True if message was sent successfully
+   */
+  bool sendFileCommand(uint8_t scq, uint8_t nos = 0);
+
+  /**
+   * @brief Send F_AF_NA_1 acknowledgment
+   * @param afq Acknowledge File Qualifier (1=pos_file, 2=neg_file,
+   * 3=pos_section, 4=neg_section)
+   * @param nos Name of section (for section acknowledgment)
+   * @return True if message was sent successfully
+   */
+  bool sendFileAck(uint8_t afq, uint8_t nos = 0);
+
+  /**
+   * @brief Calculate checksum for received data
+   * @param data Pointer to data
+   * @param length Length of data
+   * @return Calculated checksum (sum modulo 256)
+   */
+  static uint8_t calculateChecksum(const uint8_t *data, size_t length);
+
+  /**
+   * @brief Set state and notify waiters
+   * @param newState New state to set
+   */
+  void setState(FileClientState newState);
+
+  /**
+   * @brief Set error and transition to ERROR state
+   * @param error The error that occurred
+   */
+  void setError(FileClientError error);
+
+  /// @brief Weak reference to owning connection
+  std::weak_ptr<Connection> connection;
+
+  /// @brief Mutex for state access
+  mutable Module::GilAwareMutex state_mutex{"FileClient::state_mutex"};
+
+  /// @brief Condition variable for state changes
+  std::condition_variable_any state_changed;
+
+  /// @brief Current transfer state
+  std::atomic<FileClientState> state{FileClientState::IDLE};
+
+  /// @brief Last error
+  std::atomic<FileClientError> lastError{FileClientError::NONE};
+
+  /// @brief Common address for current transfer
+  uint16_t currentCA{0};
+
+  /// @brief IOA for current transfer
+  uint32_t currentIOA{0};
+
+  /// @brief Name of file (NOF) for current transfer
+  uint16_t currentNOF{0};
+
+  /// @brief Expected total file size
+  uint32_t expectedFileSize{0};
+
+  /// @brief Current section number
+  uint8_t currentSection{0};
+
+  /// @brief Expected section size
+  uint32_t expectedSectionSize{0};
+
+  /// @brief Running checksum for current section
+  uint8_t runningChecksum{0};
+
+  /// @brief Accumulated file data
+  std::vector<uint8_t> fileData;
+
+  /// @brief Section data buffer
+  std::vector<uint8_t> sectionData;
+
+  // Directory browsing state
+  /// @brief Directory entries received
+  std::vector<DirectoryEntry> directoryEntries;
+
+  /// @brief Flag indicating directory browsing is complete (LFD=1 received)
+  bool directoryComplete{false};
+
+  // Upload state
+  /// @brief Data being uploaded
+  std::vector<uint8_t> uploadData;
+
+  /// @brief Current offset in upload data
+  size_t uploadOffset{0};
+};
+
+} // namespace Remote
+
+#endif // C104_REMOTE_FILECLIENT_H


### PR DESCRIPTION
Exposes the file transfer Type IDs (120-127) from lib60870-C that were previously not bound:

- F_FR_NA_1 (120) - File ready
- F_SR_NA_1 (121) - Section ready
- F_SC_NA_1 (122) - Call directory/select file
- F_LS_NA_1 (123) - Last section/segment
- F_AF_NA_1 (124) - ACK file/section
- F_SG_NA_1 (125) - Segment
- F_DR_TA_1 (126) - Directory
- F_SC_NB_1 (127) - QueryLog

Tested against a mock server but I don't have access to real IEC 104 hardware to verify full compatibility.

Addresses #30 (partial - types only, not full file service API).