### PR TITLE
Add IEC 60870-5-101 SerialMaster

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,6 +175,8 @@ set(c104_SOURCES
     src/remote/TransportSecurity.h
     src/remote/Connection.cpp
     src/remote/Connection.h
+    src/serial/SerialMaster.cpp
+    src/serial/SerialMaster.h
     src/remote/message/IMessageInterface.h
     src/remote/message/IncomingMessage.cpp
     src/remote/message/IncomingMessage.h

--- a/src/serial/SerialMaster.cpp
+++ b/src/serial/SerialMaster.cpp
@@ -1,0 +1,293 @@
+/**
+ * Copyright 2020-2025 Fraunhofer Institute for Applied Information Technology
+ * FIT
+ *
+ * This file is part of iec104-python.
+ * iec104-python is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * iec104-python is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with iec104-python. If not, see <https://www.gnu.org/licenses/>.
+ *
+ *  See LICENSE file for the complete license text.
+ *
+ *
+ * @file SerialMaster.cpp
+ * @brief IEC 60870-5-101 master implementation
+ *
+ * @package iec104-python
+ * @namespace Serial
+ *
+ */
+
+#include "serial/SerialMaster.h"
+#include "module/ScopedGilAcquire.h"
+#include "module/ScopedGilRelease.h"
+
+#include <chrono>
+
+namespace Serial {
+
+SerialMaster::SerialMaster(const std::string &port, int baud_rate, Parity parity,
+                           int data_bits, int stop_bits, LinkLayerMode link_mode)
+    : portPath(port), baudRate(baud_rate), parity(parity),
+      dataBits(data_bits), stopBits(stop_bits), linkMode(link_mode) {
+
+  // Initialize link layer parameters with defaults
+  llParams.addressLength = 1;
+  llParams.timeoutForAck = 200;
+  llParams.timeoutRepeat = 1000;
+  llParams.useSingleCharACK = true;
+  llParams.timeoutLinkState = 3000;
+
+  // Initialize application layer parameters with defaults
+  alParams.sizeOfTypeId = 1;
+  alParams.sizeOfVSQ = 1;
+  alParams.sizeOfCOT = 2;
+  alParams.originatorAddress = 0;
+  alParams.sizeOfCA = 2;
+  alParams.sizeOfIOA = 3;
+  alParams.maxSizeOfASDU = 249;
+
+  // Create serial port
+  char parityChar = static_cast<char>(parity);
+  serialPort = SerialPort_create(port.c_str(), baud_rate, data_bits, parityChar, stop_bits);
+
+  if (!serialPort) {
+    throw std::runtime_error("Failed to create serial port: " + port);
+  }
+
+  // Open serial port
+  if (!SerialPort_open(serialPort)) {
+    SerialPort_destroy(serialPort);
+    serialPort = nullptr;
+    throw std::runtime_error("Failed to open serial port: " + port);
+  }
+
+  // Create CS101 master
+  IEC60870_LinkLayerMode mode = static_cast<IEC60870_LinkLayerMode>(link_mode);
+  master = CS101_Master_create(serialPort, &llParams, &alParams, mode);
+
+  if (!master) {
+    SerialPort_close(serialPort);
+    SerialPort_destroy(serialPort);
+    serialPort = nullptr;
+    throw std::runtime_error("Failed to create CS101 master");
+  }
+
+  // Set up callbacks
+  CS101_Master_setASDUReceivedHandler(master, asduReceivedHandler, this);
+  CS101_Master_setLinkLayerStateChanged(master, linkLayerStateChanged, this);
+  CS101_Master_setRawMessageHandler(master, rawMessageHandler, this);
+}
+
+SerialMaster::~SerialMaster() {
+  stop();
+
+  if (master) {
+    CS101_Master_destroy(master);
+    master = nullptr;
+  }
+
+  if (serialPort) {
+    SerialPort_close(serialPort);
+    SerialPort_destroy(serialPort);
+    serialPort = nullptr;
+  }
+}
+
+void SerialMaster::start() {
+  if (running.load()) {
+    return;
+  }
+
+  running.store(true);
+
+  // Start the master's internal thread
+  CS101_Master_start(master);
+
+  // Also start our own polling thread for unbalanced mode
+  if (linkMode == LinkLayerMode::UNBALANCED) {
+    runThread = new std::thread(&SerialMaster::thread_run, this);
+  }
+}
+
+void SerialMaster::stop() {
+  if (!running.load()) {
+    return;
+  }
+
+  running.store(false);
+
+  // Stop the master's internal thread
+  CS101_Master_stop(master);
+
+  // Stop our polling thread
+  {
+    std::lock_guard<std::mutex> lock(runThread_mutex);
+    runThread_wait.notify_all();
+  }
+
+  if (runThread && runThread->joinable()) {
+    runThread->join();
+    delete runThread;
+    runThread = nullptr;
+  }
+}
+
+bool SerialMaster::isRunning() const {
+  return running.load();
+}
+
+void SerialMaster::addSlave(int address) {
+  CS101_Master_addSlave(master, address);
+}
+
+void SerialMaster::pollSlave(int address) {
+  CS101_Master_pollSingleSlave(master, address);
+}
+
+void SerialMaster::useSlaveAddress(int address) {
+  CS101_Master_useSlaveAddress(master, address);
+}
+
+void SerialMaster::sendInterrogationCommand(int common_address, int qoi) {
+  CS101_Master_sendInterrogationCommand(
+      master, CS101_COT_ACTIVATION, common_address,
+      static_cast<QualifierOfInterrogation>(qoi));
+}
+
+void SerialMaster::sendCounterInterrogationCommand(int common_address, uint8_t qcc) {
+  CS101_Master_sendCounterInterrogationCommand(master, CS101_COT_ACTIVATION, common_address, qcc);
+}
+
+void SerialMaster::sendReadCommand(int common_address, int ioa) {
+  CS101_Master_sendReadCommand(master, common_address, ioa);
+}
+
+void SerialMaster::sendClockSyncCommand(int common_address) {
+  // Get current time as milliseconds since epoch
+  auto now = std::chrono::system_clock::now();
+  auto ms_since_epoch = std::chrono::duration_cast<std::chrono::milliseconds>(
+      now.time_since_epoch()).count();
+
+  struct sCP56Time2a cpTime;
+  CP56Time2a_setFromMsTimestamp(&cpTime, static_cast<uint64_t>(ms_since_epoch));
+
+  CS101_Master_sendClockSyncCommand(master, common_address, &cpTime);
+}
+
+void SerialMaster::setOnReceiveCallback(py::object &callable) {
+  py_onReceive.reset(callable);
+}
+
+void SerialMaster::setOnLinkStateChangeCallback(py::object &callable) {
+  py_onLinkStateChange.reset(callable);
+}
+
+void SerialMaster::setOnRawMessageCallback(py::object &callable) {
+  py_onRawMessage.reset(callable);
+}
+
+void SerialMaster::thread_run() {
+  while (running.load()) {
+    // In unbalanced mode, periodically run the master state machine
+    CS101_Master_run(master);
+
+    std::unique_lock<std::mutex> lock(runThread_mutex);
+    runThread_wait.wait_for(lock, std::chrono::milliseconds(10));
+  }
+}
+
+bool SerialMaster::asduReceivedHandler(void *parameter, int address, CS101_ASDU asdu) {
+  auto *self = static_cast<SerialMaster *>(parameter);
+
+  if (self->py_onReceive.is_set()) {
+    // Get ASDU info
+    int typeId = CS101_ASDU_getTypeID(asdu);
+    int ca = CS101_ASDU_getCA(asdu);
+    int cot = CS101_ASDU_getCOT(asdu);
+    int numElements = CS101_ASDU_getNumberOfElements(asdu);
+
+    // Get payload as bytes
+    int payloadSize = CS101_ASDU_getPayloadSize(asdu);
+    uint8_t* payload = CS101_ASDU_getPayload(asdu);
+
+    Module::ScopedGilAcquire const acquire("SerialMaster.on_receive");
+
+    // Create a dict with ASDU info
+    py::dict asdu_info;
+    asdu_info["type_id"] = typeId;
+    asdu_info["common_address"] = ca;
+    asdu_info["cot"] = cot;
+    asdu_info["num_elements"] = numElements;
+    if (payload && payloadSize > 0) {
+      asdu_info["payload"] = py::bytes(reinterpret_cast<char*>(payload), payloadSize);
+    }
+
+    try {
+      self->py_onReceive.call(self->shared_from_this(), asdu_info);
+    } catch (const py::error_already_set &e) {
+      // Log error but don't propagate
+    }
+  }
+
+  return true; // ASDU handled
+}
+
+void SerialMaster::linkLayerStateChanged(void *parameter, int address,
+                                          LinkLayerState state) {
+  auto *self = static_cast<SerialMaster *>(parameter);
+
+  if (self->py_onLinkStateChange.is_set()) {
+    std::string stateStr;
+    switch (state) {
+    case LL_STATE_IDLE:
+      stateStr = "IDLE";
+      break;
+    case LL_STATE_ERROR:
+      stateStr = "ERROR";
+      break;
+    case LL_STATE_BUSY:
+      stateStr = "BUSY";
+      break;
+    case LL_STATE_AVAILABLE:
+      stateStr = "AVAILABLE";
+      break;
+    default:
+      stateStr = "UNKNOWN";
+      break;
+    }
+
+    Module::ScopedGilAcquire const acquire("SerialMaster.on_link_state_change");
+    try {
+      self->py_onLinkStateChange.call(self->shared_from_this(), address, stateStr);
+    } catch (const py::error_already_set &e) {
+      // Log error but don't propagate
+    }
+  }
+}
+
+void SerialMaster::rawMessageHandler(void *parameter, uint8_t *msg, int msgSize, bool sent) {
+  auto *self = static_cast<SerialMaster *>(parameter);
+
+  if (self->py_onRawMessage.is_set()) {
+    Module::ScopedGilAcquire const acquire("SerialMaster.on_raw_message");
+    py::bytes msg_bytes(reinterpret_cast<char *>(msg), msgSize);
+
+    try {
+      self->py_onRawMessage.call(self->shared_from_this(), msg_bytes, sent);
+    } catch (const py::error_already_set &e) {
+      // Log error but don't propagate
+    }
+  }
+}
+
+} // namespace Serial

--- a/src/serial/SerialMaster.h
+++ b/src/serial/SerialMaster.h
@@ -1,0 +1,286 @@
+/**
+ * Copyright 2020-2025 Fraunhofer Institute for Applied Information Technology
+ * FIT
+ *
+ * This file is part of iec104-python.
+ * iec104-python is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * iec104-python is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with iec104-python. If not, see <https://www.gnu.org/licenses/>.
+ *
+ *  See LICENSE file for the complete license text.
+ *
+ *
+ * @file SerialMaster.h
+ * @brief IEC 60870-5-101 master (client) for serial communication
+ *
+ * @package iec104-python
+ * @namespace Serial
+ *
+ */
+
+#ifndef C104_SERIAL_MASTER_H
+#define C104_SERIAL_MASTER_H
+
+#include "types.h"
+
+#include "module/Callback.h"
+#include "module/GilAwareMutex.h"
+#include "object/Station.h"
+
+// lib60870 headers (C API) - order matters!
+extern "C" {
+#include "hal_serial.h"
+#include "link_layer_parameters.h"
+#include "iec60870_common.h"
+#include "cs101_master.h"
+}
+
+namespace Serial {
+
+/**
+ * @brief Link layer mode for IEC 101 communication
+ */
+enum class LinkLayerMode {
+  BALANCED = IEC60870_LINK_LAYER_BALANCED,
+  UNBALANCED = IEC60870_LINK_LAYER_UNBALANCED
+};
+
+/**
+ * @brief Serial port parity setting
+ */
+enum class Parity {
+  NONE = 'N',
+  EVEN = 'E',
+  ODD = 'O'
+};
+
+/**
+ * @brief IEC 60870-5-101 master for serial communication
+ */
+class SerialMaster : public std::enable_shared_from_this<SerialMaster> {
+
+public:
+  // noncopyable
+  SerialMaster(const SerialMaster &) = delete;
+  SerialMaster &operator=(const SerialMaster &) = delete;
+
+  /**
+   * @brief Factory method to create a shared pointer to a SerialMaster instance.
+   *
+   * @param port Serial port path (e.g. "/dev/ttyUSB0" or "COM1")
+   * @param baud_rate Baud rate (e.g. 9600, 19200, 115200)
+   * @param parity Parity setting (NONE, EVEN, ODD)
+   * @param data_bits Number of data bits (usually 8)
+   * @param stop_bits Number of stop bits (usually 1)
+   * @param link_mode Link layer mode (BALANCED or UNBALANCED)
+   * @return A shared pointer to the newly created SerialMaster instance.
+   */
+  [[nodiscard]] static std::shared_ptr<SerialMaster> create(
+      const std::string &port,
+      int baud_rate = 9600,
+      Parity parity = Parity::EVEN,
+      int data_bits = 8,
+      int stop_bits = 1,
+      LinkLayerMode link_mode = LinkLayerMode::UNBALANCED) {
+    return std::shared_ptr<SerialMaster>(
+        new SerialMaster(port, baud_rate, parity, data_bits, stop_bits, link_mode));
+  }
+
+  /**
+   * @brief Destructor - clean up resources
+   */
+  ~SerialMaster();
+
+  /**
+   * @brief Start the master communication thread
+   */
+  void start();
+
+  /**
+   * @brief Stop the master communication thread
+   */
+  void stop();
+
+  /**
+   * @brief Check if master is currently running
+   * @return true if running
+   */
+  bool isRunning() const;
+
+  /**
+   * @brief Add a slave to communicate with
+   * @param address Link layer address of the slave
+   */
+  void addSlave(int address);
+
+  /**
+   * @brief Poll a slave for data (unbalanced mode only)
+   * @param address Link layer address of the slave to poll
+   */
+  void pollSlave(int address);
+
+  /**
+   * @brief Set the slave address for subsequent commands
+   * @param address Link layer address
+   */
+  void useSlaveAddress(int address);
+
+  /**
+   * @brief Send general interrogation command
+   * @param common_address Common address of ASDU
+   * @param qoi Qualifier of interrogation (20 = station interrogation)
+   */
+  void sendInterrogationCommand(int common_address, int qoi = 20);
+
+  /**
+   * @brief Send counter interrogation command
+   * @param common_address Common address of ASDU
+   * @param qcc Qualifier of counter interrogation
+   */
+  void sendCounterInterrogationCommand(int common_address, uint8_t qcc = 0x05);
+
+  /**
+   * @brief Send read command
+   * @param common_address Common address of ASDU
+   * @param ioa Information object address
+   */
+  void sendReadCommand(int common_address, int ioa);
+
+  /**
+   * @brief Send clock synchronization command
+   * @param common_address Common address of ASDU
+   */
+  void sendClockSyncCommand(int common_address);
+
+  /**
+   * @brief Set callback for received ASDUs
+   */
+  void setOnReceiveCallback(py::object &callable);
+
+  /**
+   * @brief Set callback for link layer state changes
+   */
+  void setOnLinkStateChangeCallback(py::object &callable);
+
+  /**
+   * @brief Set callback for raw messages (debug)
+   */
+  void setOnRawMessageCallback(py::object &callable);
+
+  /**
+   * @brief Get the serial port path
+   */
+  std::string getPort() const { return portPath; }
+
+  /**
+   * @brief Get the baud rate
+   */
+  int getBaudRate() const { return baudRate; }
+
+  /**
+   * @brief Get the link layer mode
+   */
+  LinkLayerMode getLinkMode() const { return linkMode; }
+
+  /**
+   * @brief String representation
+   */
+  std::string toString() const {
+    std::ostringstream oss;
+    oss << "<101.SerialMaster port=" << portPath
+        << ", baud=" << baudRate
+        << ", mode=" << (linkMode == LinkLayerMode::BALANCED ? "balanced" : "unbalanced")
+        << ", running=" << (running.load() ? "true" : "false")
+        << " at " << std::hex << std::showbase << reinterpret_cast<std::uintptr_t>(this) << ">";
+    return oss.str();
+  }
+
+private:
+  /**
+   * @brief Private constructor
+   */
+  SerialMaster(const std::string &port, int baud_rate, Parity parity,
+               int data_bits, int stop_bits, LinkLayerMode link_mode);
+
+  /// @brief Serial port path
+  std::string portPath;
+
+  /// @brief Baud rate
+  int baudRate;
+
+  /// @brief Parity setting
+  Parity parity;
+
+  /// @brief Data bits
+  int dataBits;
+
+  /// @brief Stop bits
+  int stopBits;
+
+  /// @brief Link layer mode
+  LinkLayerMode linkMode;
+
+  /// @brief lib60870 serial port handle
+  SerialPort serialPort{nullptr};
+
+  /// @brief lib60870 CS101 master handle
+  CS101_Master master{nullptr};
+
+  /// @brief Link layer parameters
+  struct sLinkLayerParameters llParams;
+
+  /// @brief Application layer parameters
+  struct sCS101_AppLayerParameters alParams;
+
+  /// @brief Running state
+  std::atomic_bool running{false};
+
+  /// @brief Thread for master operations
+  std::thread *runThread{nullptr};
+
+  /// @brief Mutex for thread control
+  mutable std::mutex runThread_mutex{};
+
+  /// @brief Condition variable for thread control
+  mutable std::condition_variable runThread_wait{};
+
+  /// @brief Python callback for received ASDUs
+  Module::Callback<void> py_onReceive{
+      "SerialMaster.on_receive",
+      "(master: c104.SerialMaster, asdu: dict) -> None"};
+
+  /// @brief Python callback for link state changes
+  Module::Callback<void> py_onLinkStateChange{
+      "SerialMaster.on_link_state_change",
+      "(master: c104.SerialMaster, address: int, state: str) -> None"};
+
+  /// @brief Python callback for raw messages
+  Module::Callback<void> py_onRawMessage{
+      "SerialMaster.on_raw_message",
+      "(master: c104.SerialMaster, data: bytes, is_sent: bool) -> None"};
+
+  /// @brief Thread function
+  void thread_run();
+
+  /// @brief Static callback for received ASDUs
+  static bool asduReceivedHandler(void *parameter, int address, CS101_ASDU asdu);
+
+  /// @brief Static callback for link layer state changes
+  static void linkLayerStateChanged(void *parameter, int address, LinkLayerState state);
+
+  /// @brief Static callback for raw messages
+  static void rawMessageHandler(void *parameter, uint8_t *msg, int msgSize, bool sent);
+};
+
+} // namespace Serial
+
+#endif // C104_SERIAL_MASTER_H


### PR DESCRIPTION
Adds IEC 101 serial master support via `c104.SerialMaster`.

- Serial port communication with configurable baud/parity/data bits
- Balanced and unbalanced link layer modes
- General interrogation, counter interrogation, read, clock sync commands
- Callbacks for ASDU reception, link state changes, raw messages